### PR TITLE
Revert "fix(helm): update chart kube-prometheus-stack to 45.28.1"

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 45.28.1
+      version: 45.28.0
       sourceRef:
         kind: HelmRepository
         name: prometheus-community


### PR DESCRIPTION
Reverts smbonn2005/HomeOps#123 - bugged KPS release
failed to diff release against cluster resources: [PrometheusRule/monitoring/kube-prometheus-stack-k8s.rules dry-run failed, reason: Invalid, error: PrometheusRule.monitoring.coreos.com "kube-prometheus-stack-k8s.rules" is invalid: [spec.groups[0].rules[0].labels: Invalid value: "null"