### PR TITLE
Revert "fix(container): update image public.ecr.aws/docker/library/redis to v7.0.12"

### DIFF
--- a/kubernetes/apps/databases/redis/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/redis/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
         reloader.stakater.com/auto: "true"
     image:
       repository: public.ecr.aws/docker/library/redis
-      tag: 7.0.12
+      tag: 7.0.11
     env:
       REDIS_REPLICATION_MODE: master
     service:


### PR DESCRIPTION
Image not available yet....