### PR TITLE
chore(container): migrate unpackerr from docker.io to ghcr.io

### DIFF
--- a/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
@@ -17,8 +17,8 @@ spec:
         containers:
           app:
             image:
-              repository: docker.io/golift/unpackerr
-              tag: 0.15.2@sha256:057e34740d26c34d81ec8e2faf8ec11f8dbfc77489b7a42826f52b37e5ee1b6c
+              repository: ghcr.io/unpackerr/unpackerr
+              tag: 0.15.2@sha256:89e13608521ece21dd300c39229fd595a55fbf4b8152771af5670a7455b5c747
             env:
               TZ: America/New_York
               UN_WEBSERVER_METRICS: "true"


### PR DESCRIPTION
## Summary

Part of the broader effort tracked in #1920 to move images off Docker Hub and away from its anonymous-pull rate limits.

I audited the repo for remaining `docker.io` image references. Four apps still used Docker Hub: `mosquitto`, `unpackerr`, `cloudflared`, and `garage`. Of those, `unpackerr` is the only one with an officially-maintained, 1:1 GHCR mirror (`ghcr.io/unpackerr/unpackerr`) — the upstream project publishes to both registries from the same build. The other three (`eclipse-mosquitto`, `cloudflare/cloudflared`, `dxflrs/garage`) have no official GHCR presence, only unofficial third-party mirrors, so they're left on Docker Hub for now rather than trading a rate-limit problem for a supply-chain trust problem.

## Changes

- `kubernetes/apps/media/unpackerr/app/helmrelease.yaml`: `repository` changed from `docker.io/golift/unpackerr` to `ghcr.io/unpackerr/unpackerr`, same version (`0.15.2`), digest re-pinned to the GHCR manifest's digest (resolved directly against the GHCR registry API, not just copied from Docker Hub).

## Test plan

- [x] `kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/media/unpackerr/app` builds cleanly with the new image reference.
- [ ] Flux reconciles and the `unpackerr` pod comes up healthy on `ghcr.io/unpackerr/unpackerr:0.15.2` after merge.

Closes #1920.
