### PR TITLE
fix(rook-ceph): raise mgr memory limit to 4Gi

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -69,7 +69,7 @@ spec:
             cpu: 500m
             memory: 1Gi
           limits:
-            memory: 2Gi
+            memory: 4Gi
       storage:
         useAllNodes: true
         useAllDevices: true


### PR DESCRIPTION
## Summary
- The `2Gi` mgr memory limit added in 805f84b6 was too tight for the known ceph mgr memory leak — usage was already sitting at ~1.9Gi in steady state (`HEALTH_OK`, 2 pools, 33 PGs).
- The mgr container has been OOMKilled 3 times in the 3 days since that limit was added.
- Each OOM cycle knocked out the ceph exporter, which broke the rook-ceph `pools`/`nodes` PrometheusRule groups (11,513 rule evaluation failures observed).
- Raises the limit to `4Gi` to give headroom until the upstream leak (tracked in the existing `TODO` comment) is fixed.

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/rook-ceph/rook-ceph/cluster` — confirms `mgr.limits.memory: 4Gi` renders correctly
- [x] `bash scripts/kubeconform.sh ./kubernetes` — passes with no errors
- [ ] Confirm mgr memory usage stays below 4Gi and rule evaluation failures stop recurring once deployed