### PR TITLE
fix(kubevirt): move rps VM disk to Filesystem volumeMode

### DIFF
--- a/kubernetes/apps/kubevirt/rps/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/rps/app/virtualmachine.yaml
@@ -38,14 +38,14 @@ spec:
       volumes:
         - name: ubuntu-os
           dataVolume:
-            name: ubuntu-server
+            name: rps
         - name: cloudinit
           cloudInitNoCloud:
             secretRef:
               name: rps-cloudinit
   dataVolumeTemplates:
     - metadata:
-        name: ubuntu-server
+        name: rps
       spec:
         source:
           http:
@@ -53,6 +53,7 @@ spec:
         storage:
           accessModes:
             - ReadWriteOnce
+          volumeMode: Filesystem
           resources:
             requests:
               storage: 35Gi


### PR DESCRIPTION
## Summary
- Part of migrating `rps` off Block-mode storage so VolSync can actually back it up (see reverted #3161 / #3162 — VolSync doesn't support `volumeMode: Block` for any mover, and `ceph-block`'s `StorageProfile` forces `Block` for CDI-provisioned VM disks).
- Live cluster prep already done out-of-band ahead of this PR:
  1. Took a `VolumeSnapshot` of the original `ubuntu-server` Block PVC as a rollback point.
  2. Stopped the VM (`runStrategy: Halted`) for a clean, consistent copy.
  3. Cloned `ubuntu-server` → a new PVC named `rps` via a CDI host-assisted clone (`source: pvc`, `volumeMode: Filesystem`) — completed successfully, bound, ~38Gi.
- This PR just repoints the `VirtualMachine`'s `dataVolumeTemplates`/`volumes` at the new `rps` DataVolume/PVC instead of `ubuntu-server`, and marks the storage spec `volumeMode: Filesystem` so a from-scratch bootstrap would also come up in the right mode.
- Flux Kustomization `kubevirt-rps` is currently suspended to avoid reconciling drift mid-migration — will resume after this merges and the VM is confirmed healthy.
- Old `ubuntu-server` PVC/DataVolume is left in place for now (untouched) as a fallback until the VM is verified booting fine on the new disk.

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/kubevirt/rps/app` renders with `dataVolumeTemplates[0].metadata.name: rps`, `volumes[].dataVolume.name: rps`, `volumeMode: Filesystem`
- [x] `bash scripts/kubeconform.sh ./kubernetes` — exit 0
- [ ] Resume Flux, start the VM, confirm it boots off the new disk and `https://projects.smbonn.me/` responds
- [ ] Re-add VolSync `ReplicationSource`/`ReplicationDestination` against the new `rps` PVC once boot is confirmed