### PR TITLE
feat(kubevirt): back up rps VM disk with volsync

### DIFF
--- a/kubernetes/apps/kubevirt/rps/app/externalsecret-volsync.yaml
+++ b/kubernetes/apps/kubevirt/rps/app/externalsecret-volsync.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rps-volsync
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: rps-volsync-secret
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/rps"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .VOLSYNC_GARAGE_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .VOLSYNC_GARAGE_KEY }}"
+  dataFrom:
+    - extract:
+        key: volsync-garage-template

--- a/kubernetes/apps/kubevirt/rps/app/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/rps/app/kustomization.yaml
@@ -4,7 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - externalsecret.yaml
+  - externalsecret-volsync.yaml
   - httproute.yaml
+  - replicationdestination.yaml
+  - replicationsource.yaml
   - service.yaml
   - storageprofile-ceph.yaml
   - storageprofile-openebs.yaml

--- a/kubernetes/apps/kubevirt/rps/app/replicationdestination.yaml
+++ b/kubernetes/apps/kubevirt/rps/app/replicationdestination.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/volsync.backube/replicationdestination_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationDestination
+metadata:
+  name: rps-dst
+  labels:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+spec:
+  trigger:
+    manual: restore-once
+  restic:
+    repository: rps-volsync-secret
+    copyMethod: Snapshot
+    volumeSnapshotClassName: csi-ceph-blockpool
+    cacheStorageClassName: ceph-block
+    cacheAccessModes: ["ReadWriteOnce"]
+    cacheCapacity: 8Gi
+    storageClassName: ceph-block
+    accessModes: ["ReadWriteOnce"]
+    capacity: 35Gi
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    enableFileDeletion: true
+    cleanupCachePVC: true
+    cleanupTempPVC: true

--- a/kubernetes/apps/kubevirt/rps/app/replicationsource.yaml
+++ b/kubernetes/apps/kubevirt/rps/app/replicationsource.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: rps
+spec:
+  sourcePVC: rps
+  trigger:
+    schedule: "0 * * * *"
+  restic:
+    copyMethod: Snapshot
+    pruneIntervalDays: 14
+    repository: rps-volsync-secret
+    volumeSnapshotClassName: csi-ceph-blockpool
+    cacheCapacity: 2Gi
+    cacheStorageClassName: ceph-block
+    cacheAccessModes: ["ReadWriteOnce"]
+    storageClassName: ceph-block
+    accessModes: ["ReadWriteOnce"]
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    retain:
+      hourly: 24
+      daily: 7

--- a/kubernetes/apps/kubevirt/rps/ks.yaml
+++ b/kubernetes/apps/kubevirt/rps/ks.yaml
@@ -14,6 +14,8 @@ spec:
   dependsOn:
     - name: kubevirt-operator
     - name: kubevirt-cdi
+    - name: external-secrets-stores
+      namespace: kube-system
   path: ./kubernetes/apps/kubevirt/rps/app
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary
- Follow-up to #3163: now that `rps`'s VM disk lives on a Filesystem-mode PVC (`rps`, migrated from the original Block-mode `ubuntu-server`), VolSync's restic mover can actually mount and back it up — the original attempt (#3161, reverted in #3162) failed because VolSync doesn't support `volumeMode: Block` for any mover.
- Re-adds `ExternalSecret`/`ReplicationSource`/`ReplicationDestination` (restic repo `s3://volsync/rps`, hourly backups, 24 hourly / 7 daily retention), with `sourcePVC: rps` instead of the old `ubuntu-server` name.
- Adds `external-secrets-stores` to the Flux `Kustomization`'s `dependsOn`, matching other apps with an `ExternalSecret`.

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/kubevirt/rps/app` renders cleanly
- [x] `bash scripts/kubeconform.sh ./kubernetes` — exit 0
- [x] `flux-local test --enable-helm --all-namespaces` — 125/125 passed
- [ ] Confirm `ReplicationSource` completes a successful backup once reconciled on the live cluster (this PVC is Filesystem-mode this time, unlike the reverted attempt)