### PR TITLE
feat(gaming): add Agones gameserver framework

### DIFF
--- a/kubernetes/apps/gaming/agones/app/helmrelease.yaml
+++ b/kubernetes/apps/gaming/agones/app/helmrelease.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: agones
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: agones
+      version: 1.59.0
+      sourceRef:
+        kind: HelmRepository
+        name: agones
+  values:
+    gameservers:
+      namespaces:
+        - gaming

--- a/kubernetes/apps/gaming/agones/app/helmrepository.yaml
+++ b/kubernetes/apps/gaming/agones/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: agones
+spec:
+  interval: 1h
+  url: https://agones.dev/chart/stable

--- a/kubernetes/apps/gaming/agones/app/kustomization.yaml
+++ b/kubernetes/apps/gaming/agones/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/gaming/agones/ks.yaml
+++ b/kubernetes/apps/gaming/agones/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app agones
+  namespace: &namespace gaming
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/defaults
+  path: ./kubernetes/apps/gaming/agones/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true
+  interval: 30m
+  timeout: 5m

--- a/kubernetes/apps/gaming/example/app/gameserver.yaml
+++ b/kubernetes/apps/gaming/example/app/gameserver.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/agones.dev/gameserver_v1.json
+apiVersion: agones.dev/v1
+kind: GameServer
+metadata:
+  name: simple-game-server
+spec:
+  ports:
+    - name: default
+      portPolicy: Dynamic
+      containerPort: 7654
+  template:
+    spec:
+      containers:
+        - name: simple-game-server
+          image: us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 20m
+            limits:
+              memory: 64Mi
+              cpu: 20m

--- a/kubernetes/apps/gaming/example/app/kustomization.yaml
+++ b/kubernetes/apps/gaming/example/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./gameserver.yaml

--- a/kubernetes/apps/gaming/example/ks.yaml
+++ b/kubernetes/apps/gaming/example/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app example
+  namespace: &namespace gaming
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: agones
+  path: ./kubernetes/apps/gaming/example/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true
+  interval: 30m
+  timeout: 5m

--- a/kubernetes/apps/gaming/kustomization.yaml
+++ b/kubernetes/apps/gaming/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: gaming
+components:
+  - ../../components/common
+resources:
+  - ./agones/ks.yaml
+  - ./example/ks.yaml


### PR DESCRIPTION
## Summary
- Add a new `gaming` namespace with [Agones](https://agones.dev) (the Kubernetes gameserver controller), following the repo's usual `ks.yaml` + `app/` structure
- Agones has no OCI Helm chart, so this uses a classic `source.toolkit.fluxcd.io` `HelmRepository` (`https://agones.dev/chart/stable`) with `chart.spec.sourceRef` instead of the repo's usual `chartRef: OCIRepository` — the one intentional deviation from convention
- Set `gameservers.namespaces: [gaming]` so `GameServer`/`Fleet` objects are permitted in this namespace
- Add a sample `GameServer` (`agones.dev/v1`, `us-docker.pkg.dev/agones-images/examples/simple-game-server:0.43`) under `gaming/example/`, `dependsOn: agones` so it applies after the CRDs exist

## Test plan
- [x] `kustomize build` on `gaming/`, `gaming/agones/app/`, and `gaming/example/app/` — all render cleanly
- [x] `bash scripts/kubeconform.sh ./kubernetes` — full repo passes (`GameServer` is skipped, expected: no local schema for the Agones CRD)
- [ ] Confirm `flux-local test --enable-helm` passes in CI (couldn't get a clean local run — hit an unrelated Docker/environment issue in my sandbox)
- [ ] After merge, verify Agones reconciles and the sample `GameServer` reaches `Ready` on the live cluster