### PR TITLE
feat(container): migrate doplarr to doplarr_rs rewrite

### DIFF
--- a/kubernetes/apps/media/doplarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/doplarr/app/helmrelease.yaml
@@ -20,8 +20,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/kiranshila/doplarr
-              tag: v3.8.0@sha256:54646923c667169619c0e93c3048120f32643791ed36452066f0839e714811c9
+              repository: ghcr.io/activexray/doplarr_rs
+              tag: v4.6.0@sha256:3487e7193f14f8f7e290c69e9355a5ded548853ffa18b62178486ca33ce76820
             envFrom:
               - secretRef:
                   name: doplarr-secret


### PR DESCRIPTION
## Summary
- Doplarr has been rewritten in Rust and moved to [activexray/doplarr_rs](https://github.com/activexray/doplarr_rs); the old `kiranshila/doplarr` image is no longer maintained.
- Update `kubernetes/apps/media/doplarr/app/helmrelease.yaml` to point at `ghcr.io/activexray/doplarr_rs:v4.6.0` (latest release, pinned by digest).
- No other changes needed: per the [migration guide](https://github.com/activexray/doplarr_rs/blob/main/MIGRATING.md), the Rust build keeps backward-compatible support for the legacy `SONARR__*`/`RADARR__*`/`DISCORD__TOKEN` env vars, which is exactly what our `externalsecret.yaml` already injects — no config format (TOML) migration or secret template changes required.

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/media/doplarr/app` renders successfully
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes across the full repo
- [ ] Confirm Discord bot reconnects and Sonarr/Radarr requests still work after Flux reconciles the new image
