### PR TITLE
fix(kube-prometheus-stack): group alerts by namespace to stop duplicate Discord notifications

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -29,6 +29,7 @@ spec:
             matchType: =
     groupBy:
       - alertname
+      - namespace
       - job
     groupInterval: 5m
     groupWait: 1m


### PR DESCRIPTION
## Summary
- Alertmanager's root route grouped alerts only by `alertname` + `job`. Since many alerts (e.g. the custom `OomKilled` rule) get their `job` label from the `kube-state-metrics` exporter rather than the affected workload, unrelated OOM-kill events across the whole cluster were merged into a single alert group.
- When more than one such event landed within a `groupInterval` window (5m), Alertmanager sent an initial notification and then a follow-up for the same group as new alerts joined — showing up in Discord as duplicated alerts. Confirmed in the live Alertmanager logs: the same `OomKilled`/`kube-state-metrics` group re-notified (and truncated past 4096 runes) twice, 10 minutes apart, on two separate occasions.
- Adding `namespace` to `groupBy` scopes groups per-namespace so unrelated pods/namespaces no longer get bundled into the same notification.

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/monitoring/kube-prometheus-stack/app` builds cleanly with the updated `AlertmanagerConfig`
- [ ] Flux reconciles the change and Alertmanager picks up the new `group_by` in its live config