### PR TITLE
feat(storage): deploy kopiur backup operator

### DIFF
--- a/kubernetes/apps/storage/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/kopiur/app/helmrelease.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kopiur
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: kopiur
+  dependsOn:
+    - name: snapshot-controller
+      namespace: storage
+  values:
+    monitoring:
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          matchLabels:
+            dashboards: grafana
+      prometheusRule:
+        enabled: true
+      serviceMonitor:
+        enabled: true
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
+    resources:
+      requests:
+        cpu: 100m
+      limits:
+        memory: 2Gi

--- a/kubernetes/apps/storage/kopiur/app/kustomization.yaml
+++ b/kubernetes/apps/storage/kopiur/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/storage/kopiur/app/ocirepository.yaml
+++ b/kubernetes/apps/storage/kopiur/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kopiur
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.9.3
+  url: oci://ghcr.io/home-operations/charts/kopiur
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: '^https://token.actions.githubusercontent.com$'
+        subject: '^https://github.com/home-operations/kopiur.*$'

--- a/kubernetes/apps/storage/kopiur/ks.yaml
+++ b/kubernetes/apps/storage/kopiur/ks.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kopiur
+  namespace: &namespace storage
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/defaults
+  path: ./kubernetes/apps/storage/kopiur/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true
+  interval: 30m
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur-repository
+  namespace: storage
+spec:
+  components:
+    - ../../../../components/defaults
+    - ../../../../components/kopiur/secret
+  dependsOn:
+    - name: kopiur
+      namespace: storage
+  path: ./kubernetes/apps/storage/kopiur/repository
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: storage
+  wait: true
+  interval: 30m
+  timeout: 5m

--- a/kubernetes/apps/storage/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/storage/kopiur/repository/clusterrepository.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/kopiur.home-operations.com/clusterrepository_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: ClusterRepository
+metadata:
+  name: garage
+spec:
+  allowedNamespaces:
+    all: true
+  backend:
+    s3:
+      auth:
+        secretRef:
+          name: kopiur-repository-secret
+          namespace: storage
+      bucket: kopiur
+      endpoint: garage.storage.svc.cluster.local:3900
+      region: us-east-1
+      tls:
+        disableTls: true
+  encryption:
+    passwordSecretRef:
+      name: kopiur-repository-secret
+      namespace: storage
+      key: KOPIA_PASSWORD
+  scheduleDefaults:
+    timezone: America/New_York

--- a/kubernetes/apps/storage/kopiur/repository/kustomization.yaml
+++ b/kubernetes/apps/storage/kopiur/repository/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./clusterrepository.yaml

--- a/kubernetes/apps/storage/kustomization.yaml
+++ b/kubernetes/apps/storage/kustomization.yaml
@@ -8,5 +8,6 @@ components:
 resources:
   - ./fstrim/ks.yaml
   - ./garage/ks.yaml
+  - ./kopiur/ks.yaml
   - ./snapshot-controller/ks.yaml
   - ./volsync/ks.yaml

--- a/kubernetes/components/kopiur/backup/kustomization.yaml
+++ b/kubernetes/components/kopiur/backup/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./snapshotpolicy.yaml
+  - ./snapshotschedule.yaml
+  - ./pvc.yaml
+  - ./restore.yaml

--- a/kubernetes/components/kopiur/backup/pvc.yaml
+++ b/kubernetes/components/kopiur/backup/pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "${CLAIM:-${APP}}"
+spec:
+  accessModes: ["${KOPIUR_ACCESSMODES:-ReadWriteOnce}"]
+  dataSourceRef:
+    apiGroup: kopiur.home-operations.com
+    kind: Restore
+    name: "${APP}"
+  resources:
+    requests:
+      storage: "${KOPIUR_CAPACITY:=5Gi}"
+  storageClassName: "${KOPIUR_STORAGECLASS:=ceph-block}"

--- a/kubernetes/components/kopiur/backup/restore.yaml
+++ b/kubernetes/components/kopiur/backup/restore.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/kopiur.home-operations.com/restore_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: "${APP}"
+spec:
+  policy:
+    onMissingSnapshot: Continue
+  source:
+    fromPolicy:
+      name: "${APP}"
+      offset: 0
+  target:
+    populator: {}

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: "${APP}"
+spec:
+  compression:
+    compressor: zstd
+  mover:
+    cache:
+      capacity: "${KOPIUR_CACHE_CAPACITY:=2Gi}"
+      mode: Persistent
+      storageClassName: "${KOPIUR_STORAGECLASS:=ceph-block}"
+    securityContext:
+      runAsUser: ${KOPIUR_PUID:=1000}
+      runAsGroup: ${KOPIUR_PGID:=1000}
+  repository:
+    kind: ClusterRepository
+    name: garage
+  retention:
+    keepHourly: 24
+    keepDaily: 7
+  sources:
+    - pvc:
+        name: "${CLAIM:-${APP}}"
+  volumeSnapshotClassName: "${KOPIUR_SNAPSHOTCLASS:=csi-ceph-blockpool}"

--- a/kubernetes/components/kopiur/backup/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotschedule.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: "${APP}"
+spec:
+  policyRef:
+    name: "${APP}"
+  schedule:
+    cron: "H * * * *"

--- a/kubernetes/components/kopiur/readme.md
+++ b/kubernetes/components/kopiur/readme.md
@@ -1,0 +1,79 @@
+# Kopiur Template
+
+The `kopiur` operator + `ClusterRepository` (`kubernetes/apps/storage/kopiur`)
+are deployed. These per-app components (`./secret`, `./backup`) are not yet
+wired into any app — hold off referencing them from an app's `ks.yaml`
+until the operator has been confirmed healthy on the live cluster. See the
+VolSync equivalent at `../volsync` for the pattern this replaces.
+
+This layout is adapted from a known-working production deployment of this
+chart, keeping the operator and repository in this repo's existing
+`storage` namespace instead of a dedicated `kopiur-system` one.
+Unlike VolSync (one restic repo per app, isolated by path prefix), Kopiur
+here uses a **single shared `ClusterRepository`** (`garage`, defined in
+`kubernetes/apps/storage/kopiur/repository`) — one secret, one bucket,
+referenced by every app's `SnapshotPolicy`.
+
+## Two components, two different places to add them
+
+- `./secret` — the shared `kopiur-repository-secret` `ExternalSecret`. Must
+  be added once to **every namespace's top-level `kustomization.yaml`**
+  that has an app using Kopiur (not per-app) — Kopiur's mover pods run in
+  the app's own namespace and can only mount a `Secret` that exists
+  locally there, so the secret needs to exist in `storage` (for the
+  `ClusterRepository` controller itself) *and* in each consuming
+  namespace. This is why `kopiur-repository/ks.yaml` also pulls in
+  `../../../../components/kopiur/secret`.
+- `./backup` — the per-app `SnapshotPolicy`/`SnapshotSchedule`/`Restore`/PVC,
+  added to an individual app's `ks.yaml` `components:`, same as VolSync's
+  component was.
+
+## Flux Kustomization
+
+This requires `postBuild` configured on the Flux Kustomization
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app plex
+  namespace: flux-system
+spec:
+  # ...
+  postBuild:
+    substitute:
+      APP: *app
+      KOPIUR_CAPACITY: 5Gi
+```
+
+and then call the components in your application's `ks.yaml` and the
+app's namespace `kustomization.yaml`:
+
+```yaml
+# apps/<namespace>/<app>/ks.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+spec:
+  components:
+    - ../../../../components/kopiur/backup
+```
+
+```yaml
+# apps/<namespace>/kustomization.yaml
+components:
+  - ../../components/kopiur/secret
+```
+
+## Required `postBuild` vars
+
+- `APP`: The application name
+- `KOPIUR_CAPACITY`: The PVC size (also used as the mover's cache PVC size)
+
+## Optional `postBuild` vars
+
+- `CLAIM`: PVC name, if different from `APP`
+- `KOPIUR_ACCESSMODES`: default `ReadWriteOnce`
+- `KOPIUR_STORAGECLASS`: default `ceph-block`
+- `KOPIUR_CACHE_CAPACITY`: default `2Gi`
+- `KOPIUR_SNAPSHOTCLASS`: default `csi-ceph-blockpool`
+- `KOPIUR_PUID` / `KOPIUR_PGID`: default `1000`

--- a/kubernetes/components/kopiur/secret/externalsecret.yaml
+++ b/kubernetes/components/kopiur/secret/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kopiur-repository
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: kopiur-repository-secret
+    template:
+      data:
+        KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: kopiur

--- a/kubernetes/components/kopiur/secret/kustomization.yaml
+++ b/kubernetes/components/kopiur/secret/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./externalsecret.yaml


### PR DESCRIPTION
## Summary
- Deploys the [kopiur](https://github.com/home-operations/kopiur) operator + a shared `ClusterRepository` (Garage S3 backend, `kopiur` bucket) in the `storage` namespace, as the first step toward replacing VolSync.
- Adds the per-app `kopiur/backup` (SnapshotPolicy/SnapshotSchedule/Restore/PVC) and `kopiur/secret` components — intended to mirror the existing `components/volsync` pattern for future app migrations, but **nothing consumes them yet**. No app's `ks.yaml` or namespace `kustomization.yaml` references them in this PR.
- Chart version pinned to `0.9.3` with a cosign `verify` block on the `OCIRepository`, confirmed against the real published signature via `cosign verify` (both the exact-workflow and shortened repo-level `matchOIDCIdentity` subjects were validated locally).
- Because this repo runs upstream VolSync + restic (not the `perfectra1n/volsync` kopia fork), Kopiur cannot adopt existing restic snapshots — it starts with a brand-new, empty repository. VolSync stays fully in place; no existing app is touched.

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes clean, including the new `storage/kopiur` app and `storage/kopiur/repository` Kustomizations.
- [x] `kustomize build` of `components/kopiur/backup` + `components/kopiur/secret` with `postBuild` vars substituted at their documented defaults validates clean against real schemas (PVC, ExternalSecret); the alpha `kopiur.home-operations.com` CRDs correctly skip (no published schema, same as other custom CRDs in this repo).
- [x] `cosign verify` against `ghcr.io/home-operations/charts/kopiur:0.9.3` confirms the OIDC identity pinned in the `OCIRepository` actually matches the published signature.
- [ ] Not yet verified against a live Flux reconcile — once this merges and the operator/`ClusterRepository` come up healthy on the cluster, the next step is wiring `kopiur/backup` into a single low-stakes app to test end-to-end before any broader rollout.