### PR TITLE
feat(speedtest): pilot kopiur backup on speedtest

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: default
 components:
   - ../../components/common
+  - ../../components/kopiur/secret
 resources:
   - ./bookstack/ks.yaml
   - ./homepage/ks.yaml

--- a/kubernetes/apps/default/speedtest/app/helmrelease.yaml
+++ b/kubernetes/apps/default/speedtest/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
+    - name: kopiur-repository
       namespace: storage
   values:
     controllers:

--- a/kubernetes/apps/default/speedtest/ks.yaml
+++ b/kubernetes/apps/default/speedtest/ks.yaml
@@ -10,7 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
     - ../../../../components/defaults
   dependsOn:
     - name: cloudnative-pg-cluster
@@ -30,4 +30,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 1Gi
+      KOPIUR_CAPACITY: 1Gi

--- a/kubernetes/components/kopiur/readme.md
+++ b/kubernetes/components/kopiur/readme.md
@@ -1,10 +1,12 @@
 # Kopiur Template
 
 The `kopiur` operator + `ClusterRepository` (`kubernetes/apps/storage/kopiur`)
-are deployed. These per-app components (`./secret`, `./backup`) are not yet
-wired into any app — hold off referencing them from an app's `ks.yaml`
-until the operator has been confirmed healthy on the live cluster. See the
-VolSync equivalent at `../volsync` for the pattern this replaces.
+are deployed and healthy. `speedtest` (`apps/default/speedtest`) is the
+first app piloting these components, replacing its `components/volsync`
+usage — chosen because losing its backup history is low-stakes while
+Kopiur proves itself. Other apps should stay on `../volsync` until the
+speedtest pilot has been verified (snapshot taken, restore-via-populator
+confirmed on a PVC recreate) before rolling further.
 
 This layout is adapted from a known-working production deployment of this
 chart, keeping the operator and repository in this repo's existing


### PR DESCRIPTION
## Summary
- Swaps `speedtest` from `components/volsync` to `components/kopiur/backup` (first live pilot of the VolSync -> Kopiur migration from #3200).
- Adds `components/kopiur/secret` to the `default` namespace so the mover pod can mount the shared repository credentials locally.
- Updates `speedtest`'s HelmRelease `dependsOn` from `volsync`/storage to `kopiur-repository`/storage.
- speedtest was chosen deliberately: its backup history has near-zero value, so accepting a fresh/empty kopia repository (per the known restic/kopia repository-format incompatibility) is a low-risk way to prove the operator end-to-end, including the `Restore`-as-populator PVC creation path.
- No other app is touched — everything else stays on VolSync until this pilot is verified.

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes clean.
- [ ] After merge, confirm on the live cluster: `speedtest` PVC binds via the Kopiur `Restore` populator, `SnapshotPolicy`/`SnapshotSchedule` reconcile, a snapshot is taken on schedule, and a manual restore test succeeds before rolling this out further.