### PR TITLE
fix(speedtest): match kopiur mover uid/gid to the linuxserver image

### DIFF
--- a/kubernetes/apps/default/speedtest/ks.yaml
+++ b/kubernetes/apps/default/speedtest/ks.yaml
@@ -34,3 +34,5 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
+      KOPIUR_PUID: "911"
+      KOPIUR_PGID: "911"


### PR DESCRIPTION
## Summary
A manual `Snapshot` triggered against speedtest's `SnapshotPolicy` (created directly via the `kopiur.home-operations.com/v1alpha1 Snapshot` CRD, `policyRef: {name: speedtest}`) failed:

```
snapshot create failed (class PermissionDenied): ...
Error when processing "keys/cert.key": unable to open file: ... permission denied
Error when processing "log/logrotate.status": unable to open file: ... permission denied
```

Confirmed via `kubectl exec` into the running pod: `lscr.io/linuxserver/speedtest-tracker` runs its app as the image's internal `abc` user, uid/gid **911** (not the SnapshotPolicy component's default `1000:1000`). Those two files are owned `abc:abc` with restrictive permissions (`660`/`600`), so the mover running as uid 1000 couldn't read them mid-snapshot.

- Sets `KOPIUR_PUID`/`KOPIUR_PGID: "911"` via `postBuild.substitute` on speedtest's `ks.yaml`, matching the actual container user.
- No other app is affected — this is a per-app override, not a change to the component's defaults.

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes clean.
- [x] Verified locally with `kustomize build` + var substitution that `KOPIUR_PUID=911`/`KOPIUR_PGID=911` render as valid unquoted integers in the `SnapshotPolicy`'s `mover.securityContext`.
- [ ] After merge, re-trigger a manual `Snapshot` against speedtest and confirm it completes successfully this time.