### PR TITLE
feat(speedtest): cut over fully to kopiur

### DIFF
--- a/kubernetes/apps/default/speedtest/app/helmrelease.yaml
+++ b/kubernetes/apps/default/speedtest/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
+    - name: kopiur-repository
       namespace: storage
   values:
     controllers:

--- a/kubernetes/apps/default/speedtest/ks.yaml
+++ b/kubernetes/apps/default/speedtest/ks.yaml
@@ -10,8 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/volsync
-    - ../../../../components/kopiur/snapshot
+    - ../../../../components/kopiur/backup
     - ../../../../components/defaults
   dependsOn:
     - name: cloudnative-pg-cluster
@@ -33,6 +32,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 1Gi
+      KOPIUR_CAPACITY: 1Gi
       KOPIUR_PUID: "911"
       KOPIUR_PGID: "911"

--- a/kubernetes/components/kopiur/readme.md
+++ b/kubernetes/components/kopiur/readme.md
@@ -1,12 +1,11 @@
 # Kopiur Template
 
 The `kopiur` operator + `ClusterRepository` (`kubernetes/apps/storage/kopiur`)
-are deployed and healthy. `speedtest` (`apps/default/speedtest`) is the
-first app piloting these components — chosen because losing its backup
-history is low-stakes while Kopiur proves itself. Other apps should stay
-on `../volsync` until the speedtest pilot has been fully verified (a
-snapshot taken of real data, then a PVC recreated from it via the
-populator) before rolling further.
+are deployed and healthy. `speedtest` (`apps/default/speedtest`) piloted
+these components: a manual snapshot of its live VolSync-owned PVC
+succeeded, then it was cut over to `./backup` (VolSync removed, PVC
+recreated via the `Restore` populator) as the first full migration. Other
+apps should follow the same two-step procedure below before switching.
 
 ## Four components
 


### PR DESCRIPTION
## Summary
Completes the speedtest pilot from #3201/#3202/#3203. A manual `Snapshot` of speedtest's live VolSync-owned PVC succeeded end-to-end (kopia snapshot `960dcc67a06cf49c25dbb998fd6c0bce`, 43 files, confirmed via the `garage` `ClusterRepository`'s catalog), after fixing the mover's uid/gid to match the `linuxserver` image.

- `speedtest/ks.yaml`: drops `components/volsync`, switches to `components/kopiur/backup` (bundles `SnapshotPolicy`/`SnapshotSchedule` + PVC/`Restore` populator). `KOPIUR_CAPACITY: 1Gi` replaces `VOLSYNC_CAPACITY`; `KOPIUR_PUID`/`KOPIUR_PGID: "911"` carried over from #3203.
- `speedtest/app/helmrelease.yaml`: `dependsOn` moves from `volsync`/storage to `kopiur-repository`/storage.
- `readme.md` updated to record speedtest as a completed migration and point future app migrations at the same two-step procedure.

## Important: live-cluster step required after merge
`PersistentVolumeClaim.spec.dataSourceRef` is immutable once bound (this is exactly what blocked #3201 originally). Merging this PR alone will **not** apply cleanly — the existing VolSync-owned `speedtest` PVC has to be deleted first so the new `Restore` populator can recreate it from the snapshot already taken. That's a live-cluster action (scale pod to 0, delete PVC, let Flux reconcile), not something this PR does — will be handled as a follow-up after merge with explicit confirmation before deleting anything.

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes clean.
- [ ] After merge: delete the old PVC, confirm the `speedtest` Kustomization reconciles, the new PVC binds via the `Restore` populator using the existing snapshot, and the pod comes back healthy.