### PR TITLE
fix(speedtest): correct HelmRelease dependsOn target

### DIFF
--- a/kubernetes/apps/default/speedtest/app/helmrelease.yaml
+++ b/kubernetes/apps/default/speedtest/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: kopiur-repository
+    - name: kopiur
       namespace: storage
   values:
     controllers:


### PR DESCRIPTION
## Summary
speedtest's `HelmRelease` was stuck not-ready:
```
unable to get 'storage/kopiur-repository' dependency: helmreleases.helm.toolkit.fluxcd.io "kopiur-repository" not found
```
`HelmRelease.spec.dependsOn` resolves against other `HelmRelease` objects, not Flux `Kustomization`s. `kopiur-repository` is the Kustomization that applies the `ClusterRepository` CR (correctly referenced at the Kustomization level in `speedtest/ks.yaml`'s own `spec.dependsOn`, which does support that) — it was a mistake to reuse that same name here. The actual operator HelmRelease is named `kopiur`.

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes clean.
- [ ] After merge, confirm `flux get helmreleases speedtest -n default` reports `Ready: True`.