### PR TITLE
feat(kopiur): step-1 snapshot alongside volsync for remaining apps

### DIFF
--- a/kubernetes/apps/default/bookstack/ks.yaml
+++ b/kubernetes/apps/default/bookstack/ks.yaml
@@ -11,10 +11,13 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/kopiur/snapshot
     - ../../../../components/defaults
   dependsOn:
     - name: mariadb-cluster
       namespace: databases
+    - name: kopiur-repository
+      namespace: storage
   path: ./kubernetes/apps/default/bookstack/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/mealie/ks.yaml
+++ b/kubernetes/apps/default/mealie/ks.yaml
@@ -11,6 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/kopiur/snapshot
     - ../../../../components/defaults
   path: ./kubernetes/apps/default/mealie/app
   dependsOn:
@@ -18,6 +19,8 @@ spec:
       namespace: databases
     - name: external-secrets-stores
       namespace: kube-system
+    - name: kopiur-repository
+      namespace: storage
   prune: true
   sourceRef:
     kind: GitRepository
@@ -31,3 +34,5 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 10Gi
+      KOPIUR_PUID: "911"
+      KOPIUR_PGID: "911"

--- a/kubernetes/apps/default/pterodactyl/ks.yaml
+++ b/kubernetes/apps/default/pterodactyl/ks.yaml
@@ -11,10 +11,13 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/kopiur/snapshot
     - ../../../../components/defaults
   dependsOn:
     - name: mariadb-cluster
       namespace: databases
+    - name: kopiur-repository
+      namespace: storage
   path: ./kubernetes/apps/default/pterodactyl/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/default/qbittorrent/ks.yaml
+++ b/kubernetes/apps/default/qbittorrent/ks.yaml
@@ -11,7 +11,11 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/kopiur/snapshot
     - ../../../../components/defaults
+  dependsOn:
+    - name: kopiur-repository
+      namespace: storage
   path: ./kubernetes/apps/default/qbittorrent/app
   prune: true
   sourceRef:
@@ -26,3 +30,5 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
+      KOPIUR_PUID: "568"
+      KOPIUR_PGID: "568"

--- a/kubernetes/apps/home-automation/home-assistant/ks.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/ks.yaml
@@ -11,10 +11,13 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/kopiur/snapshot
     - ../../../../components/defaults
   dependsOn:
     - name: external-secrets-stores
       namespace: kube-system
+    - name: kopiur-repository
+      namespace: storage
   path: ./kubernetes/apps/home-automation/home-assistant/app
   prune: true
   sourceRef:
@@ -29,3 +32,5 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 2Gi
+      KOPIUR_PUID: "568"
+      KOPIUR_PGID: "568"

--- a/kubernetes/apps/home-automation/kustomization.yaml
+++ b/kubernetes/apps/home-automation/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: home-automation
 components:
   - ../../components/common
+  - ../../components/kopiur/secret
 resources:
   - ./home-assistant/ks.yaml
   - ./mosquitto/ks.yaml

--- a/kubernetes/apps/home-automation/mosquitto/ks.yaml
+++ b/kubernetes/apps/home-automation/mosquitto/ks.yaml
@@ -11,10 +11,13 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/kopiur/snapshot
     - ../../../../components/defaults
   dependsOn:
     - name: external-secrets-stores
       namespace: kube-system
+    - name: kopiur-repository
+      namespace: storage
   path: ./kubernetes/apps/home-automation/mosquitto/app
   prune: true
   sourceRef:
@@ -29,3 +32,5 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
+      KOPIUR_PUID: "568"
+      KOPIUR_PGID: "568"

--- a/kubernetes/apps/home-automation/zigbee2mqtt/ks.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/ks.yaml
@@ -10,10 +10,13 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/kopiur/snapshot
     - ../../../../components/defaults
   dependsOn:
     - name: external-secrets-stores
       namespace: kube-system
+    - name: kopiur-repository
+      namespace: storage
   path: ./kubernetes/apps/home-automation/zigbee2mqtt/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: media
 components:
   - ../../components/common
+  - ../../components/kopiur/secret
 resources:
   - ./plex/ks.yaml
   - ./sonarr/ks.yaml

--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -11,10 +11,13 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/kopiur/snapshot
     - ../../../../components/defaults
   dependsOn:
     - name: external-secrets-stores
       namespace: kube-system
+    - name: kopiur-repository
+      namespace: storage
   path: ./kubernetes/apps/media/plex/app
   prune: true
   sourceRef:
@@ -30,3 +33,5 @@ spec:
       APP: *app
       VOLSYNC_CAPACITY: 100Gi
       VOLSYNC_CACHE_CAPACITY: 20Gi
+      KOPIUR_PUID: "568"
+      KOPIUR_PGID: "568"

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -11,10 +11,13 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/kopiur/snapshot
     - ../../../../components/defaults
   dependsOn:
     - name: external-secrets-stores
       namespace: kube-system
+    - name: kopiur-repository
+      namespace: storage
   path: ./kubernetes/apps/media/prowlarr/app
   prune: true
   sourceRef:
@@ -29,3 +32,5 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 2Gi
+      KOPIUR_PUID: "568"
+      KOPIUR_PGID: "568"

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -11,10 +11,13 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/kopiur/snapshot
     - ../../../../components/defaults
   dependsOn:
     - name: external-secrets-stores
       namespace: kube-system
+    - name: kopiur-repository
+      namespace: storage
   path: ./kubernetes/apps/media/radarr/app
   prune: true
   sourceRef:
@@ -29,3 +32,5 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 15Gi
+      KOPIUR_PUID: "568"
+      KOPIUR_PGID: "568"

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -11,10 +11,13 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/kopiur/snapshot
     - ../../../../components/defaults
   dependsOn:
     - name: external-secrets-stores
       namespace: kube-system
+    - name: kopiur-repository
+      namespace: storage
   path: ./kubernetes/apps/media/sonarr/app
   prune: true
   sourceRef:
@@ -29,3 +32,5 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 15Gi
+      KOPIUR_PUID: "568"
+      KOPIUR_PGID: "568"

--- a/kubernetes/apps/media/tautulli/ks.yaml
+++ b/kubernetes/apps/media/tautulli/ks.yaml
@@ -11,7 +11,11 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+    - ../../../../components/kopiur/snapshot
     - ../../../../components/defaults
+  dependsOn:
+    - name: kopiur-repository
+      namespace: storage
   path: ./kubernetes/apps/media/tautulli/app
   prune: true
   sourceRef:
@@ -26,3 +30,5 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 15Gi
+      KOPIUR_PUID: "568"
+      KOPIUR_PGID: "568"


### PR DESCRIPTION
## Summary
Applies step 1 of the documented migration procedure (`kubernetes/components/kopiur/readme.md`) to every remaining VolSync-backed app, the same pattern proven safe on speedtest (#3201-#3205): add `components/kopiur/snapshot` alongside the existing `components/volsync`, with **no PVC changes at all**. VolSync keeps owning every PVC and keeps backing it up exactly as before; this purely adds a parallel `SnapshotPolicy`/`SnapshotSchedule` so Kopiur starts building real backup history against each app's live data.

Apps: `bookstack`, `mealie`, `pterodactyl`, `qbittorrent` (default) · `home-assistant`, `mosquitto`, `zigbee2mqtt` (home-automation) · `plex`, `prowlarr`, `radarr`, `sonarr`, `tautulli` (media).

- Wires `components/kopiur/secret` into the `home-automation` and `media` namespace `kustomization.yaml`s (`default` already had it).
- Adds `kopiur-repository`/storage to each app's Kustomization-level `dependsOn`.
- Sets `KOPIUR_PUID`/`KOPIUR_PGID` per app to match its **actual running container user**, checked live via `kubectl exec ... id` and file ownership (auth keys, DB files) rather than assumed — this is exactly the class of bug hit and fixed for speedtest in #3203, applied proactively here:
  - `568:568` — qbittorrent, home-assistant, mosquitto, plex, prowlarr, radarr, sonarr, tautulli
  - `911:911` — mealie (linuxserver-style `abc` user, same as speedtest)
  - left at the component default `1000:1000` — bookstack (its `abc` user genuinely is 1000:1000), pterodactyl and zigbee2mqtt (verified all files are world-readable, so uid mismatch doesn't matter currently)

`kubevirt/rps` is intentionally excluded — it uses a bespoke VolSync setup (not this shared component) and has its own storage-mode history (see prior VolSync Block→Filesystem migration) worth handling as its own follow-up.

This PR does **not** cut any app over to Kopiur — that's a separate follow-up per app once each one's snapshots are confirmed landing cleanly, same two-step process as speedtest.

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes clean across the whole tree.
- [ ] After merge: confirm all 12 `SnapshotPolicy`/`SnapshotSchedule` pairs reconcile `Ready: True`, and spot-check a manual `Snapshot` per app (or wait for the hourly schedule) to confirm the PUID/PGID guesses were correct — particularly bookstack/pterodactyl/zigbee2mqtt, which are relying on world-readable permissions rather than an exact uid/gid match.