### PR TITLE
feat(tautulli): cut over fully to kopiur

### DIFF
--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
+    - name: kopiur
       namespace: storage
   values:
     controllers:

--- a/kubernetes/apps/media/tautulli/ks.yaml
+++ b/kubernetes/apps/media/tautulli/ks.yaml
@@ -10,8 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/volsync
-    - ../../../../components/kopiur/snapshot
+    - ../../../../components/kopiur/backup
     - ../../../../components/defaults
   dependsOn:
     - name: kopiur-repository
@@ -29,6 +28,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 15Gi
+      KOPIUR_CAPACITY: 15Gi
       KOPIUR_PUID: "568"
       KOPIUR_PGID: "568"

--- a/kubernetes/components/kopiur/readme.md
+++ b/kubernetes/components/kopiur/readme.md
@@ -1,11 +1,11 @@
 # Kopiur Template
 
 The `kopiur` operator + `ClusterRepository` (`kubernetes/apps/storage/kopiur`)
-are deployed and healthy. `speedtest` (`apps/default/speedtest`) piloted
-these components: a manual snapshot of its live VolSync-owned PVC
-succeeded, then it was cut over to `./backup` (VolSync removed, PVC
-recreated via the `Restore` populator) as the first full migration. Other
-apps should follow the same two-step procedure below before switching.
+are deployed and healthy. Every VolSync-backed app except `kubevirt/rps`
+is on step 1 (`./snapshot` alongside `./volsync`, verified backing up
+cleanly overnight). `speedtest` and `tautulli` have been fully cut over to
+`./backup`; the rest will follow the same two-step procedure below one at
+a time.
 
 ## Four components
 


### PR DESCRIPTION
## Summary
Second app fully migrated off VolSync, following the exact procedure proven on speedtest (#3201-#3205). Tautulli's step-1 `SnapshotPolicy` (added in #3206) has been backing up its live PVC cleanly overnight with no issues, confirming the `KOPIUR_PUID`/`KOPIUR_PGID: 568` guess was correct (matches its HelmRelease's `pod.securityContext.runAsUser/runAsGroup: 568` exactly).

- `tautulli/ks.yaml`: drops `components/volsync`, switches to `components/kopiur/backup`. `KOPIUR_CAPACITY: 15Gi` replaces `VOLSYNC_CAPACITY`.
- `tautulli/app/helmrelease.yaml`: `dependsOn` moves from `volsync`/storage to `kopiur`/storage.
- `readme.md` updated to reflect the migration's progress.

## Important: live-cluster step required after merge
Same as speedtest: `PersistentVolumeClaim.spec.dataSourceRef` is immutable once bound, so merging this alone won't apply cleanly — the existing VolSync-owned `tautulli` PVC needs deleting first so the `Restore` populator can recreate it from an already-taken snapshot. That's a live-cluster action (scale pod to 0, delete PVC, reconcile), handled as a follow-up after merge with explicit confirmation, not by this PR.

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes clean.
- [ ] After merge: trigger a fresh snapshot if needed, delete the old PVC, confirm the `tautulli` Kustomization + HelmRelease both reconcile `Ready: True`, the new PVC binds via the `Restore` populator, and the pod comes back healthy with its data intact.