### PR TITLE
feat(kopiur): cut over all remaining apps to kopiur

### DIFF
--- a/kubernetes/apps/default/bookstack/app/helmrelease.yaml
+++ b/kubernetes/apps/default/bookstack/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
+    - name: kopiur
       namespace: storage
   values:
     controllers:

--- a/kubernetes/apps/default/bookstack/ks.yaml
+++ b/kubernetes/apps/default/bookstack/ks.yaml
@@ -10,8 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/volsync
-    - ../../../../components/kopiur/snapshot
+    - ../../../../components/kopiur/backup
     - ../../../../components/defaults
   dependsOn:
     - name: mariadb-cluster
@@ -31,4 +30,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 1Gi
+      KOPIUR_CAPACITY: 1Gi

--- a/kubernetes/apps/default/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mealie/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
+    - name: kopiur
       namespace: storage
   values:
     controllers:

--- a/kubernetes/apps/default/mealie/ks.yaml
+++ b/kubernetes/apps/default/mealie/ks.yaml
@@ -10,8 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/volsync
-    - ../../../../components/kopiur/snapshot
+    - ../../../../components/kopiur/backup
     - ../../../../components/defaults
   path: ./kubernetes/apps/default/mealie/app
   dependsOn:
@@ -33,6 +32,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 10Gi
+      KOPIUR_CAPACITY: 10Gi
       KOPIUR_PUID: "911"
       KOPIUR_PGID: "911"

--- a/kubernetes/apps/default/pterodactyl/app/helmrelease.yaml
+++ b/kubernetes/apps/default/pterodactyl/app/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
       namespace: databases
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
+    - name: kopiur
       namespace: storage
   values:
     controllers:

--- a/kubernetes/apps/default/pterodactyl/ks.yaml
+++ b/kubernetes/apps/default/pterodactyl/ks.yaml
@@ -10,8 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/volsync
-    - ../../../../components/kopiur/snapshot
+    - ../../../../components/kopiur/backup
     - ../../../../components/defaults
   dependsOn:
     - name: mariadb-cluster
@@ -31,4 +30,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 20Gi
+      KOPIUR_CAPACITY: 20Gi

--- a/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
+    - name: kopiur
       namespace: storage
   values:
     controllers:

--- a/kubernetes/apps/default/qbittorrent/ks.yaml
+++ b/kubernetes/apps/default/qbittorrent/ks.yaml
@@ -10,8 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/volsync
-    - ../../../../components/kopiur/snapshot
+    - ../../../../components/kopiur/backup
     - ../../../../components/defaults
   dependsOn:
     - name: kopiur-repository
@@ -29,6 +28,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 1Gi
+      KOPIUR_CAPACITY: 1Gi
       KOPIUR_PUID: "568"
       KOPIUR_PGID: "568"

--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
+    - name: kopiur
       namespace: storage
   values:
     controllers:

--- a/kubernetes/apps/home-automation/home-assistant/ks.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/ks.yaml
@@ -10,8 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/volsync
-    - ../../../../components/kopiur/snapshot
+    - ../../../../components/kopiur/backup
     - ../../../../components/defaults
   dependsOn:
     - name: external-secrets-stores
@@ -31,6 +30,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 2Gi
+      KOPIUR_CAPACITY: 2Gi
       KOPIUR_PUID: "568"
       KOPIUR_PGID: "568"

--- a/kubernetes/apps/home-automation/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mosquitto/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
+    - name: kopiur
       namespace: storage
   values:
     controllers:

--- a/kubernetes/apps/home-automation/mosquitto/ks.yaml
+++ b/kubernetes/apps/home-automation/mosquitto/ks.yaml
@@ -10,8 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/volsync
-    - ../../../../components/kopiur/snapshot
+    - ../../../../components/kopiur/backup
     - ../../../../components/defaults
   dependsOn:
     - name: external-secrets-stores
@@ -31,6 +30,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 1Gi
+      KOPIUR_CAPACITY: 1Gi
       KOPIUR_PUID: "568"
       KOPIUR_PGID: "568"

--- a/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
+    - name: kopiur
       namespace: storage
     - name: mosquitto
       namespace: home-automation

--- a/kubernetes/apps/home-automation/zigbee2mqtt/ks.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/ks.yaml
@@ -9,8 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/volsync
-    - ../../../../components/kopiur/snapshot
+    - ../../../../components/kopiur/backup
     - ../../../../components/defaults
   dependsOn:
     - name: external-secrets-stores
@@ -30,4 +29,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 1Gi
+      KOPIUR_CAPACITY: 1Gi

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
       namespace: kube-system
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
+    - name: kopiur
       namespace: storage
   values:
     controllers:

--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -10,8 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/volsync
-    - ../../../../components/kopiur/snapshot
+    - ../../../../components/kopiur/backup
     - ../../../../components/defaults
   dependsOn:
     - name: external-secrets-stores
@@ -31,7 +30,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 100Gi
-      VOLSYNC_CACHE_CAPACITY: 20Gi
+      KOPIUR_CAPACITY: 100Gi
+      KOPIUR_CACHE_CAPACITY: 20Gi
       KOPIUR_PUID: "568"
       KOPIUR_PGID: "568"

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
+    - name: kopiur
       namespace: storage
   values:
     controllers:

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -10,8 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/volsync
-    - ../../../../components/kopiur/snapshot
+    - ../../../../components/kopiur/backup
     - ../../../../components/defaults
   dependsOn:
     - name: external-secrets-stores
@@ -31,6 +30,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 2Gi
+      KOPIUR_CAPACITY: 2Gi
       KOPIUR_PUID: "568"
       KOPIUR_PGID: "568"

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
+    - name: kopiur
       namespace: storage
     - name: prowlarr
       namespace: media

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -10,8 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/volsync
-    - ../../../../components/kopiur/snapshot
+    - ../../../../components/kopiur/backup
     - ../../../../components/defaults
   dependsOn:
     - name: external-secrets-stores
@@ -31,6 +30,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 15Gi
+      KOPIUR_CAPACITY: 15Gi
       KOPIUR_PUID: "568"
       KOPIUR_PGID: "568"

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
   dependsOn:
     - name: rook-ceph-cluster
       namespace: rook-ceph
-    - name: volsync
+    - name: kopiur
       namespace: storage
     - name: prowlarr
       namespace: media

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -10,8 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/volsync
-    - ../../../../components/kopiur/snapshot
+    - ../../../../components/kopiur/backup
     - ../../../../components/defaults
   dependsOn:
     - name: external-secrets-stores
@@ -31,6 +30,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 15Gi
+      KOPIUR_CAPACITY: 15Gi
       KOPIUR_PUID: "568"
       KOPIUR_PGID: "568"

--- a/kubernetes/components/kopiur/readme.md
+++ b/kubernetes/components/kopiur/readme.md
@@ -2,10 +2,8 @@
 
 The `kopiur` operator + `ClusterRepository` (`kubernetes/apps/storage/kopiur`)
 are deployed and healthy. Every VolSync-backed app except `kubevirt/rps`
-is on step 1 (`./snapshot` alongside `./volsync`, verified backing up
-cleanly overnight). `speedtest` and `tautulli` have been fully cut over to
-`./backup`; the rest will follow the same two-step procedure below one at
-a time.
+is fully cut over to `./backup` (VolSync removed). `kubevirt/rps` uses a
+bespoke, non-component VolSync setup and needs its own migration plan.
 
 ## Four components
 


### PR DESCRIPTION
## Summary
Completes the VolSync -> Kopiur migration for every remaining app: `bookstack`, `mealie`, `pterodactyl`, `qbittorrent` (default) · `home-assistant`, `mosquitto`, `zigbee2mqtt` (home-automation) · `plex`, `prowlarr`, `radarr`, `sonarr` (media). Each has had its step-1 `SnapshotPolicy` (#3206) backing up cleanly overnight, plus a manual verification `Snapshot` confirmed against every one of them (files/sizes checked, PUID/PGID guesses all correct — see prior conversation, e.g. plex's full 100Gi/82k-file snapshot succeeded).

Same change shape as speedtest (#3204) and tautulli (#3213), applied to all 11 at once since they're all equally proven:
- Drops `components/volsync`, switches to `components/kopiur/backup`.
- `VOLSYNC_CAPACITY` → `KOPIUR_CAPACITY` (`VOLSYNC_CACHE_CAPACITY` → `KOPIUR_CACHE_CAPACITY` for plex specifically).
- Each `HelmRelease`'s `dependsOn` moves from `volsync`/storage to `kopiur`/storage directly (the corrected form from #3205 — no `kopiur-repository` naming mistake this time).

`kubevirt/rps` remains out of scope — bespoke non-component VolSync setup, separate follow-up.

## Important: live-cluster step required per app after merge
Same as every prior cutover: `PersistentVolumeClaim.spec.dataSourceRef` is immutable once bound, so each app's existing VolSync-owned PVC needs deleting before its `Restore` populator can recreate it from the snapshot already taken. That's 11 separate live-cluster actions (scale pod to 0, delete PVC, reconcile, verify, scale back up) — handled as follow-ups after merge, one at a time, with confirmation before each deletion, not by this PR.

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes clean across the whole tree.
- [x] Confirmed no app still references `components/volsync` or leftover `VOLSYNC_*`/`name: volsync` after the edits.
- [ ] After merge: work through each app's PVC swap, confirming the Kustomization + HelmRelease reconcile `Ready: True`, the new PVC binds via the `Restore` populator, and the pod comes back healthy with data intact.