### PR TITLE
feat(kopiur): step-1 snapshot for rps alongside its bespoke volsync setup

### DIFF
--- a/kubernetes/apps/kubevirt/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: kubevirt
 components:
   - ../../components/common
+  - ../../components/kopiur/secret
 resources:
   - ./cdi/ks.yaml
   - ./operator/ks.yaml

--- a/kubernetes/apps/kubevirt/rps/ks.yaml
+++ b/kubernetes/apps/kubevirt/rps/ks.yaml
@@ -10,12 +10,15 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
+    - ../../../../components/kopiur/snapshot
     - ../../../../components/defaults
   dependsOn:
     - name: kubevirt-operator
     - name: kubevirt-cdi
     - name: external-secrets-stores
       namespace: kube-system
+    - name: kopiur-repository
+      namespace: storage
   path: ./kubernetes/apps/kubevirt/rps/app
   prune: true
   sourceRef:
@@ -26,3 +29,6 @@ spec:
   wait: true
   interval: 30m
   timeout: 5m
+  postBuild:
+    substitute:
+      APP: rps

--- a/kubernetes/components/kopiur/readme.md
+++ b/kubernetes/components/kopiur/readme.md
@@ -1,9 +1,15 @@
 # Kopiur Template
 
 The `kopiur` operator + `ClusterRepository` (`kubernetes/apps/storage/kopiur`)
-are deployed and healthy. Every VolSync-backed app except `kubevirt/rps`
-is fully cut over to `./backup` (VolSync removed). `kubevirt/rps` uses a
-bespoke, non-component VolSync setup and needs its own migration plan.
+are deployed and healthy. Every other VolSync-backed app is fully cut over
+to `./backup` (VolSync removed). `kubevirt/rps` is on step 1 only
+(`./snapshot` alongside its existing bespoke VolSync setup, not the shared
+`../volsync` component) — its disk PVC comes from a KubeVirt
+`dataVolumeTemplate` embedded in `virtualmachine.yaml`, not a plain
+`PersistentVolumeClaim`, so it can't use `./populate` the way every other
+app did. Cutting it over fully needs research into whether CDI's
+`DataVolume` can target a Kopiur `Restore` as a populator, ideally proven
+out against a throwaway VM first — not attempted yet.
 
 ## Four components
 


### PR DESCRIPTION
## Summary
`rps` (a KubeVirt `VirtualMachine`) doesn't fit the cutover pattern used for every other app in this migration:

- Its disk PVC comes from a `dataVolumeTemplate` embedded in `virtualmachine.yaml`, not a standalone `PersistentVolumeClaim` — `components/kopiur/populate` (a plain PVC + `Restore` populator) isn't directly usable here.
- The live PVC's `dataSourceRef` already points at CDI's own `VolumeCloneSource` populator, not VolSync's `ReplicationDestination`. Checking the live `DataVolume`, its actual source doesn't even match what's committed in `virtualmachine.yaml` (`dataVolumeTemplates[0].spec.source.http`) — it was provisioned once, manually, and DataVolumes aren't reconciled again after creation. Restoring this VM's disk from a VolSync backup is already a manual, out-of-band DR procedure today, not something automatically wired in.
- It's the VM's boot disk — meaningfully higher blast radius than a container's config volume if something goes wrong.

Given that, this PR does **step 1 only**: adds `components/kopiur/snapshot` alongside rps's existing bespoke `replicationsource.yaml`/`replicationdestination.yaml` (it predates and doesn't use the shared `components/volsync` template either) to start backing up the live `rps` PVC with Kopiur in parallel. No changes to the VM, its disk, or its provisioning. Full cutover is a separate follow-up pending research into whether CDI's `DataVolume` can target a Kopiur `Restore` as a populator — ideally proven out against a throwaway VM first, not the production one.

- Wires `components/kopiur/secret` into the `kubevirt` namespace kustomization.
- No `KOPIUR_PUID`/`KOPIUR_PGID` override — VolSync's restic mover already succeeds against this exact PVC with the same `1000:1000` `moverSecurityContext` that's the kopiur snapshot component's default, so it should work unmodified.

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes clean.
- [ ] After merge: confirm the `kubevirt-rps` Kustomization reconciles `Ready: True`, the `SnapshotPolicy`/`SnapshotSchedule` come up, and trigger a manual snapshot to confirm the `1000:1000` mover can actually read the VM's disk content.