### PR TITLE
feat(rps): cut over boot disk to kopiur, bypassing CDI's DataVolume

### DIFF
--- a/kubernetes/apps/kubevirt/rps/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/rps/app/virtualmachine.yaml
@@ -37,24 +37,9 @@ spec:
           pod: {}
       volumes:
         - name: ubuntu-os
-          dataVolume:
-            name: rps
+          persistentVolumeClaim:
+            claimName: rps
         - name: cloudinit
           cloudInitNoCloud:
             secretRef:
               name: rps-cloudinit
-  dataVolumeTemplates:
-    - metadata:
-        name: rps
-      spec:
-        source:
-          http:
-            url: https://cloud-images.ubuntu.com/releases/resolute/release/ubuntu-26.04-server-cloudimg-amd64.vmdk
-        storage:
-          accessModes:
-            - ReadWriteOnce
-          volumeMode: Filesystem
-          resources:
-            requests:
-              storage: 35Gi
-          storageClassName: ceph-block

--- a/kubernetes/apps/kubevirt/rps/ks.yaml
+++ b/kubernetes/apps/kubevirt/rps/ks.yaml
@@ -11,6 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/kopiur/snapshot
+    - ../../../../components/kopiur/populate
     - ../../../../components/defaults
   dependsOn:
     - name: kubevirt-operator
@@ -32,3 +33,4 @@ spec:
   postBuild:
     substitute:
       APP: rps
+      KOPIUR_CAPACITY: 35Gi

--- a/kubernetes/components/kopiur/readme.md
+++ b/kubernetes/components/kopiur/readme.md
@@ -1,15 +1,19 @@
 # Kopiur Template
 
 The `kopiur` operator + `ClusterRepository` (`kubernetes/apps/storage/kopiur`)
-are deployed and healthy. Every other VolSync-backed app is fully cut over
-to `./backup` (VolSync removed). `kubevirt/rps` is on step 1 only
-(`./snapshot` alongside its existing bespoke VolSync setup, not the shared
-`../volsync` component) — its disk PVC comes from a KubeVirt
-`dataVolumeTemplate` embedded in `virtualmachine.yaml`, not a plain
-`PersistentVolumeClaim`, so it can't use `./populate` the way every other
-app did. Cutting it over fully needs research into whether CDI's
-`DataVolume` can target a Kopiur `Restore` as a populator, ideally proven
-out against a throwaway VM first — not attempted yet.
+are deployed and healthy. Every app is on `./backup`/`./populate`, VolSync
+removed, except `kubevirt/rps`: CDI's `DataVolume` only supports its own
+fixed set of source types (confirmed against the live CRD schema, plus
+[cdi-populators.md](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/cdi-populators.md)) —
+it can't be pointed at a Kopiur `Restore`. Instead, `rps` dropped
+`dataVolumeTemplates` entirely and now references a plain,
+`./populate`-managed PVC directly via
+`volumes[].persistentVolumeClaim.claimName`, the same shape every other
+app uses. Its VolSync `ReplicationSource`/`ReplicationDestination` are
+deliberately still in place as a fallback (harmless — VolSync just backs
+up whatever PVC is named `rps`, regardless of how it's populated) until
+the Kopiur-populated boot is verified working; remove them in a follow-up
+once confirmed.
 
 ## Four components
 


### PR DESCRIPTION
## Summary
Research confirmed CDI's `DataVolume.spec.source` (checked against the live CRD schema, CDI v1.65.0) is a fixed, closed set of source types — `blank`/`gcs`/`http`/`imageio`/`pvc`/`registry`/`s3`/`snapshot`/`upload`/`vddk` — with no generic populator-reference field. Confirmed against [cdi-populators.md](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/cdi-populators.md): CDI's populator extensibility (e.g. Forklift's oVirt/OpenStack populators) requires CDI itself to ship recognition for that specific CRD; a third-party CRD like Kopiur's `Restore` can't plug in. So `components/kopiur/populate` can never work through a `dataVolumeTemplate`.

The fix: `rps` doesn't need `dataVolumeTemplates` for its *ongoing* disk lifecycle — that mechanism exists to answer "populate this disk from an external source once." This PR drops it entirely and switches the `ubuntu-os` volume to a direct PVC reference (`volumes[].persistentVolumeClaim.claimName: rps`), the same shape every other migrated app already uses. `components/kopiur/populate` now owns that PVC.

- `virtualmachine.yaml`: removes `dataVolumeTemplates`, `ubuntu-os` volume switches from `dataVolume: {name: rps}` to `persistentVolumeClaim: {claimName: rps}`.
- `ks.yaml`: adds `components/kopiur/populate` alongside the existing `components/kopiur/snapshot`, `KOPIUR_CAPACITY: 35Gi` (matching the disk's current size).
- The step-1 `SnapshotPolicy` has been backing up this exact PVC hourly since the last PR, plus a verified manual snapshot (`disk.img`, ~35GB) — so the `Restore` populator restores from real data, not an empty repository.
- **VolSync's `ReplicationSource`/`ReplicationDestination` are deliberately left in place**, not removed in this PR — this is the first time a KubeVirt boot disk in this cluster has been populated via Kopiur instead of CDI, so I'd rather confirm the VM actually boots before pulling the fallback. They coexist fine since VolSync just backs up whatever PVC is named `rps`.

## Important: live-cluster step required after merge
Same shape as every other cutover, but higher stakes (VM boot disk, first time this exact combination has been tested): stop the VM (`virtctl stop rps`, not a forced delete), delete the old PVC *and* the CDI `DataVolume` object (it's synthesized by `virt-controller` from `dataVolumeTemplates` at runtime, not Kustomize-managed, so it won't self-prune when the template block is removed from git — needs explicit deletion), reconcile, confirm the new PVC binds via `Restore`, `virtctl start rps`, verify the VM actually boots and is reachable before considering this done.

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes clean.
- [x] Built the full merged manifest set (`app/` + `kopiur/snapshot` + `kopiur/populate` components) standalone with `kustomize build`, substituted `postBuild` vars, and validated with `kubeconform` — the new `PersistentVolumeClaim rps` renders and validates against the real schema, no resource name collisions across all 13 resources.
- [ ] After merge: live VM disk cutover per above, with the VolSync fallback intentionally still available if the boot fails.