### PR TITLE
fix(rps): bump kopiur PVC capacity to fit the actual disk

### DIFF
--- a/kubernetes/apps/kubevirt/rps/ks.yaml
+++ b/kubernetes/apps/kubevirt/rps/ks.yaml
@@ -33,4 +33,4 @@ spec:
   postBuild:
     substitute:
       APP: rps
-      KOPIUR_CAPACITY: 35Gi
+      KOPIUR_CAPACITY: 40Gi


### PR DESCRIPTION
## Summary
Caught this in the dry-run before doing the live cutover from #3216: the current live `rps` PVC's `status.capacity` is `38Gi` (raw ~37.1GiB) despite the nominal disk size being 35Gi — filesystem formatting overhead on a Filesystem-mode volume. The kopiur `SnapshotPolicy` already confirmed the kopia snapshot's logical size is exactly `37580963840` bytes (exactly 35Gi), so a fresh PVC requesting only `35Gi` would likely not have enough usable space after formatting to hold that restored file, risking the `Restore` populator failing mid-write.

Bumps `KOPIUR_CAPACITY` from `35Gi` to `40Gi` — comfortably above the proven-working `38Gi`.

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes clean.
- [ ] Proceed with the live cutover from #3216 once merged.