### PR TITLE
feat(konflate): deploy konflate for rendered Flux PR diffs

### DIFF
--- a/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: konflate-webhook-token
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: konflate-webhook-token-secret
+    template:
+      data:
+        KONFLATE_WEBHOOK_SECRET: "{{ .KONFLATE_WEBHOOK_SECRET }}"
+        KONFLATE_APP_CLIENT_ID: "{{ .GITHUB_BOT_APP_CLIENT_ID }}"
+        KONFLATE_APP_PRIVATE_KEY: "{{ .GITHUB_BOT_APP_PRIVATE_KEY }}"
+  dataFrom:
+    - extract:
+        key: konflate
+    - extract:
+        key: github-bot

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: konflate
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: konflate
+  interval: 1h
+  values:
+    config:
+      repo: github://smbonn2005/HomeOps
+      statusChecks: true
+      prComments: true
+      publicUrl: https://{{ .Release.Name }}.smbonn.me
+      mcp: true
+      verifyImages: true
+    secret:
+      existingSecret: konflate-webhook-token-secret
+    httpRoute:
+      enabled: true
+      annotations:
+        gatus.home-operations.com/endpoint: |-
+          conditions: ["[STATUS] == 200"]
+      parentRefs:
+        - name: envoy-external
+          namespace: networking
+      hostnames:
+        - "{{ .Release.Name }}.smbonn.me"
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    resources:
+      requests:
+        cpu: 50m
+      limits:
+        memory: 1Gi

--- a/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
@@ -2,10 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: flux-system
-components:
-  - ../../components/common
 resources:
-  - ./flux-instance/ks.yaml
-  - ./flux-operator/ks.yaml
-  - ./konflate/ks.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/flux-system/konflate/app/ocirepository.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/ocirepository.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: konflate
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.4.3
+  url: oci://ghcr.io/home-operations/charts/konflate
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: '^https://token.actions.githubusercontent.com$'
+        subject: '^https://github.com/home-operations/konflate.*$'

--- a/kubernetes/apps/flux-system/konflate/ks.yaml
+++ b/kubernetes/apps/flux-system/konflate/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev//kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app konflate
+  namespace: &namespace flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/defaults
+  path: ./kubernetes/apps/flux-system/konflate/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false
+  interval: 1h
+  timeout: 5m


### PR DESCRIPTION
## Summary
- Adds konflate (HelmRelease, OCIRepository, ExternalSecret) under `kubernetes/apps/flux-system/konflate`
- Wires `konflate/ks.yaml` into `kubernetes/apps/flux-system/kustomization.yaml` so Flux actually reconciles it
- `ks.yaml` follows the standard flux-system pattern (`&app`/`&namespace` anchors, `commonMetadata.labels`, `components: [defaults]`)

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/flux-system/konflate/app` renders cleanly
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes for the whole repo, including the new konflate manifests
- [x] `kustomize build kubernetes/apps/flux-system` confirms the konflate Kustomization is now part of the reconciled tree
- [ ] Confirm the `konflate` and `github-bot` 1Password items exist with the expected fields (`KONFLATE_WEBHOOK_SECRET`, `GITHUB_BOT_APP_CLIENT_ID`, `GITHUB_BOT_APP_PRIVATE_KEY`) before merge