### PR TITLE
fix(monitoring): wire up nut-exporter and smartctl-exporter grafana dashboards

### DIFF
--- a/kubernetes/apps/monitoring/exporters/nut-exporter/app/dashboard/grafanadashboard.yaml
+++ b/kubernetes/apps/monitoring/exporters/nut-exporter/app/dashboard/grafanadashboard.yaml
@@ -6,6 +6,7 @@ metadata:
   name: nut-exporter
 spec:
   allowCrossNamespaceImport: true
+  folder: monitoring
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/exporters/nut-exporter/app/dashboard/grafanadashboard.yaml
+++ b/kubernetes/apps/monitoring/exporters/nut-exporter/app/dashboard/grafanadashboard.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: nut-exporter
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  configMapRef:
+    name: nut-exporter-dashboard
+    key: nut-exporter.json

--- a/kubernetes/apps/monitoring/exporters/nut-exporter/app/dashboard/kustomization.yaml
+++ b/kubernetes/apps/monitoring/exporters/nut-exporter/app/dashboard/kustomization.yaml
@@ -2,6 +2,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+resources:
+  - ./grafanadashboard.yaml
 configMapGenerator:
   - name: nut-exporter-dashboard
     files:

--- a/kubernetes/apps/monitoring/exporters/nut-exporter/app/dashboard/kustomization.yaml
+++ b/kubernetes/apps/monitoring/exporters/nut-exporter/app/dashboard/kustomization.yaml
@@ -15,6 +15,5 @@ generatorOptions:
   disableNameSuffixHash: true
   annotations:
     kustomize.toolkit.fluxcd.io/substitute: disabled
-    grafana_folder: "monitoring"
   labels:
     grafana_dashboard: "true"

--- a/kubernetes/apps/monitoring/exporters/nut-exporter/app/dashboard/kustomization.yaml
+++ b/kubernetes/apps/monitoring/exporters/nut-exporter/app/dashboard/kustomization.yaml
@@ -15,6 +15,6 @@ generatorOptions:
   disableNameSuffixHash: true
   annotations:
     kustomize.toolkit.fluxcd.io/substitute: disabled
-    grafana_folder: "default"
+    grafana_folder: "monitoring"
   labels:
     grafana_dashboard: "true"

--- a/kubernetes/apps/monitoring/exporters/smartctl-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/monitoring/exporters/smartctl-exporter/app/grafanadashboard.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: smartctl-exporter
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  grafanaCom:
+    id: 22604
+    revision: 2

--- a/kubernetes/apps/monitoring/exporters/smartctl-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/exporters/smartctl-exporter/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./prometheusrule.yaml


### PR DESCRIPTION
## Summary
- Fixes the `nut-exporter` dashboard, which was only ever provisioned as a `ConfigMap` for the old Grafana sidecar discovery pattern — a mechanism no longer in use now that Grafana runs via `grafana-operator` (`grafana.enabled: false`). Adds a `GrafanaDashboard` CR with `configMapRef` pointing at the existing ConfigMap, and sets `spec.folder: monitoring` explicitly (the old `grafana_folder` annotation only applied to the unused sidecar mechanism and had no effect under grafana-operator).
- Adds a new `smartctl-exporter` Grafana dashboard (grafana.com ID 22604), wired the same way as the other custom dashboards in this repo (`instanceSelector: {dashboards: grafana}`).

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone` on both affected apps renders cleanly with correct namespace/labels
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes (exit 0) for the full tree
- [x] `flate test all --path ./kubernetes/flux/cluster` — 178 passed, no new failures