### PR TITLE
chore(monitoring): move smartctl and zfs dashboards to storage folder

### DIFF
--- a/kubernetes/apps/monitoring/exporters/smartctl-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/monitoring/exporters/smartctl-exporter/app/grafanadashboard.yaml
@@ -6,6 +6,7 @@ metadata:
   name: smartctl-exporter
 spec:
   allowCrossNamespaceImport: true
+  folder: storage
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/scrapeconfigs/nas-exporter/grafanadashboard.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/scrapeconfigs/nas-exporter/grafanadashboard.yaml
@@ -6,6 +6,7 @@ metadata:
   name: zfs
 spec:
   allowCrossNamespaceImport: true
+  folder: storage
   instanceSelector:
     matchLabels:
       dashboards: grafana


### PR DESCRIPTION
## Summary
- Sets `spec.folder: storage` on the `smartctl-exporter` and `zfs` (NAS) `GrafanaDashboard` CRs so they land in the "storage" folder in Grafana instead of the default folder.

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone` on both affected apps renders with `folder: storage` set
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes (exit 0) for the full tree