### PR TITLE
feat(monitoring): alert on unhealthy zfs pool state

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/scrapeconfigs/nas-exporter/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/scrapeconfigs/nas-exporter/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./grafanadashboard.yaml
   - ./nas-exporter.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/scrapeconfigs/nas-exporter/prometheusrule.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/scrapeconfigs/nas-exporter/prometheusrule.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: nas-exporter
+spec:
+  groups:
+    - name: nas-exporter.rules
+      rules:
+        - alert: ZfsPoolUnhealthy
+          annotations:
+            summary: ZFS pool {{ $labels.zpool }} on {{ $labels.instance }} is {{ $labels.state }}.
+          expr: node_zfs_zpool_state{state!="online"} == 1
+          for: 5m
+          labels:
+            severity: critical


### PR DESCRIPTION
## Summary
- Adds a `ZfsPoolUnhealthy` `PrometheusRule` in the `nas-exporter` folder, firing when `node_zfs_zpool_state` reports any pool in a non-online state (degraded, faulted, offline, removed, suspended, unavail) for 5+ minutes, at `severity: critical` (routed to Discord per the existing Alertmanager config).

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone` renders the rule with correct namespace
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes (exit 0) for the full tree
- [x] `promtool check rules` on the rendered rule — valid
- [x] `flate test all --path ./kubernetes/flux/cluster` — 178 passed, no new failures
- [x] Verified against live Prometheus data: expression currently returns no results (`Main_Pool` and `boot-pool` are both online), confirming no false-fire on the healthy path