### PR TITLE
feat(databases): alert on mariadb galera cluster health

### DIFF
--- a/kubernetes/apps/databases/mariadb/cluster/kustomization.yaml
+++ b/kubernetes/apps/databases/mariadb/cluster/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   # - ./backup.yaml --- Not deploying yet, waiting for Garage deployment ---
   - ./externalsecret.yaml
   - ./mariadb.yaml
+  - ./prometheusrule.yaml
 
   # Databases
   # Pterodactyl

--- a/kubernetes/apps/databases/mariadb/cluster/prometheusrule.yaml
+++ b/kubernetes/apps/databases/mariadb/cluster/prometheusrule.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: mariadb
+spec:
+  groups:
+    - name: mariadb.rules
+      rules:
+        - alert: MariadbGaleraClusterSizeDegraded
+          annotations:
+            summary: MariaDB Galera cluster size is {{ $value }} on {{ $labels.instance }}, below the expected 3 nodes.
+          expr: mysql_global_status_wsrep_cluster_size < 3
+          for: 5m
+          labels:
+            severity: warning
+        - alert: MariadbGaleraNotPrimaryComponent
+          annotations:
+            summary: MariaDB node {{ $labels.instance }} is not part of the Primary component and cannot safely serve reads/writes.
+          expr: mysql_global_status_wsrep_cluster_status != 1
+          for: 2m
+          labels:
+            severity: critical
+        - alert: MariadbGaleraNodeNotReady
+          annotations:
+            summary: MariaDB node {{ $labels.instance }} is not ready to accept queries.
+          expr: mysql_global_status_wsrep_ready != 1
+          for: 2m
+          labels:
+            severity: critical
+        - alert: MariadbGaleraNodeDisconnected
+          annotations:
+            summary: MariaDB node {{ $labels.instance }} is disconnected from the Galera cluster.
+          expr: mysql_global_status_wsrep_connected != 1
+          for: 2m
+          labels:
+            severity: critical
+        - alert: MariadbGaleraNodeNotSynced
+          annotations:
+            summary: MariaDB node {{ $labels.instance }} has not been in the Synced state for over 10 minutes.
+          expr: mysql_global_status_wsrep_local_state != 4
+          for: 10m
+          labels:
+            severity: warning


### PR DESCRIPTION
## Summary
- The MariaDB Galera cluster (`mariadb-0/1/2`) has `metrics.enabled`/`serviceMonitor.enabled` and is feeding cluster-health metrics into Prometheus (`wsrep_cluster_size`, `wsrep_cluster_status`, `wsrep_ready`, `wsrep_connected`, `wsrep_local_state`), but had zero alerting on top of it — a split-brain, lost quorum, or a node silently dropping out of the cluster would raise nothing.
- Adds 5 rules in `kubernetes/apps/databases/mariadb/cluster/prometheusrule.yaml`:
  - `MariadbGaleraClusterSizeDegraded` — cluster size < 3 nodes (warning)
  - `MariadbGaleraNotPrimaryComponent` — node not in the Primary component, can't safely serve reads/writes (critical)
  - `MariadbGaleraNodeNotReady` — node not ready for queries (critical)
  - `MariadbGaleraNodeDisconnected` — node disconnected from the cluster (critical)
  - `MariadbGaleraNodeNotSynced` — node stuck out of Synced state for 10m+, tolerant of normal SST/IST during a restart (warning)

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone` renders the rule with correct namespace
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes (exit 0) for the full tree
- [x] `promtool check rules` on the rendered rule set — 5 rules found, valid
- [x] `flate test all --path ./kubernetes/flux/cluster` — 178 passed, no new failures
- [x] Verified each expression against live Prometheus data: all 5 currently return zero results (cluster is healthy), confirming no false-fire on the happy path