### PR TITLE
fix(envoy-gateway): pin hass.smbonn.me listener to HTTP/1.1

### DIFF
--- a/kubernetes/apps/networking/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/networking/envoy-gateway/app/envoy.yaml
@@ -80,6 +80,17 @@ spec:
         certificateRefs:
           - kind: Secret
             name: smbonn-me-tls
+    - name: https-hass
+      hostname: hass.smbonn.me
+      protocol: HTTPS
+      port: 443
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: smbonn-me-tls
 ---
 # yaml-language-server: $schema=https://cluster-schemas.smbonn.me/gateway.networking.k8s.io/gateway_v1.json
 apiVersion: gateway.networking.k8s.io/v1
@@ -193,3 +204,34 @@ spec:
           requestRedirect:
             scheme: https
             statusCode: 301
+---
+# yaml-language-server: $schema=https://cluster-schemas.smbonn.me/gateway.envoyproxy.io/clienttrafficpolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: hass-http1-only
+spec:
+  # Home Assistant's companion app opens a persistent websocket (/api/websocket) using
+  # the classic Connection:Upgrade handshake, which HTTP/2 (and HTTP/3) don't support.
+  # Scoped to the hass-only listener (sectionName) so it doesn't affect h2/h3 elsewhere;
+  # ClientTrafficPolicy doesn't merge, so shared settings are duplicated from the `envoy` policy.
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: envoy-external
+      sectionName: https-hass
+  clientIPDetection:
+    xForwardedFor:
+      trustedCIDRs:
+        - 10.42.0.0/16
+  connection:
+    bufferLimit: 8Mi
+    maxAcceptPerSocketEvent: 0
+  tcpKeepalive: {}
+  timeout:
+    http:
+      requestReceivedTimeout: 0s
+  tls:
+    minVersion: "1.2"
+    alpnProtocols:
+      - http/1.1


### PR DESCRIPTION
## Summary
- Home Assistant companion app reported intermittent "Unable to connect to Home Assistant" errors, even though the same URL always worked fine in a browser.
- Root cause: the app's persistent websocket (`/api/websocket`) uses the classic `Connection: Upgrade` handshake, which HTTP/2 doesn't support. The shared `ClientTrafficPolicy` offers `h2` via ALPN on every gateway listener, so whenever the app's HTTP connection pool reuses (or opens) an h2 connection to `hass.smbonn.me`, the upgrade is rejected. Reproduced directly against the live cluster:
  - Over HTTP/2: `400` — `"No WebSocket UPGRADE hdr: None. Can 'Upgrade' only to 'WebSocket'."`
  - Same request forced to HTTP/1.1: `101 Switching Protocols`, then HA's normal `{"type":"auth_required",...}`.
  - This explains the intermittency: ALPN is fixed per-TCP-connection, so the failure depends on whatever connection happens to be sitting in the app's pool at reconnect time, not something a WiFi toggle or reboot can reliably fix.
- Rather than dropping `h2` cluster-wide (nothing else needs it — no `GRPCRoute`s exist), adds a hostname-scoped `https-hass` listener on `envoy-external` (SNI-based, same port) with its own `ClientTrafficPolicy` targeting just that listener via `sectionName`, restricting ALPN to `http/1.1`. Everything else keeps h2.
- Duplicates `clientIPDetection`/`connection`/`tcpKeepalive`/`timeout`/`tls.minVersion` from the shared `envoy` policy since Envoy Gateway's `ClientTrafficPolicy` doesn't merge — a listener-scoped policy fully replaces the gateway-level one for that listener.

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/networking/envoy-gateway/app` renders cleanly
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes for the full tree, including the new `Gateway` listener and `ClientTrafficPolicy hass-http1-only`
- [ ] After merge/reconcile, confirm the HA companion app connects reliably (including after periods of app backgrounding, to rule out the connection-pool race)