### PR TITLE
fix(envoy-gateway): disable HTTP/2 downstream to fix hass websocket

### DIFF
--- a/kubernetes/apps/networking/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/networking/envoy-gateway/app/envoy.yaml
@@ -80,17 +80,6 @@ spec:
         certificateRefs:
           - kind: Secret
             name: smbonn-me-tls
-    - name: https-hass
-      hostname: hass.smbonn.me
-      protocol: HTTPS
-      port: 443
-      allowedRoutes:
-        namespaces:
-          from: All
-      tls:
-        certificateRefs:
-          - kind: Secret
-            name: smbonn-me-tls
 ---
 # yaml-language-server: $schema=https://cluster-schemas.smbonn.me/gateway.networking.k8s.io/gateway_v1.json
 apiVersion: gateway.networking.k8s.io/v1
@@ -165,11 +154,6 @@ spec:
   connection:
     bufferLimit: 8Mi
     maxAcceptPerSocketEvent: 0
-  http2:
-    initialStreamWindowSize: 2Mi
-    initialConnectionWindowSize: 32Mi
-    onInvalidMessage: TerminateStream
-  http3: {}
   targetSelectors:
     - group: gateway.networking.k8s.io
       kind: Gateway
@@ -180,7 +164,6 @@ spec:
   tls:
     minVersion: "1.2"
     alpnProtocols:
-      - h2
       - http/1.1
 ---
 # yaml-language-server: $schema=https://cluster-schemas.smbonn.me/gateway.networking.k8s.io/httproute_v1.json
@@ -204,34 +187,3 @@ spec:
           requestRedirect:
             scheme: https
             statusCode: 301
----
-# yaml-language-server: $schema=https://cluster-schemas.smbonn.me/gateway.envoyproxy.io/clienttrafficpolicy_v1alpha1.json
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: ClientTrafficPolicy
-metadata:
-  name: hass-http1-only
-spec:
-  # Home Assistant's companion app opens a persistent websocket (/api/websocket) using
-  # the classic Connection:Upgrade handshake, which HTTP/2 (and HTTP/3) don't support.
-  # Scoped to the hass-only listener (sectionName) so it doesn't affect h2/h3 elsewhere;
-  # ClientTrafficPolicy doesn't merge, so shared settings are duplicated from the `envoy` policy.
-  targetRefs:
-    - group: gateway.networking.k8s.io
-      kind: Gateway
-      name: envoy-external
-      sectionName: https-hass
-  clientIPDetection:
-    xForwardedFor:
-      trustedCIDRs:
-        - 10.42.0.0/16
-  connection:
-    bufferLimit: 8Mi
-    maxAcceptPerSocketEvent: 0
-  tcpKeepalive: {}
-  timeout:
-    http:
-      requestReceivedTimeout: 0s
-  tls:
-    minVersion: "1.2"
-    alpnProtocols:
-      - http/1.1


### PR DESCRIPTION
## Summary

Follow-up/correction to #3251, which broke browser access to `hass.smbonn.me` entirely (companion app worked, all browser access - on and off the home network - failed with "Unable to connect to Home Assistant").

- #3251's approach (a hostname-scoped `https-hass` listener with its own `ClientTrafficPolicy` restricting ALPN to `http/1.1`, leaving `h2` everywhere else) doesn't actually achieve isolation. Every app on `envoy-external` shares one LB IP (`192.168.1.221`) and one `*.smbonn.me` cert. Browsers implement **HTTP/2 connection coalescing** (RFC 7540 §9.1.1): if a browser already has an open h2 connection to *any* app under the same IP+cert, it will silently reuse that connection for `hass.smbonn.me` too - entirely client-side, before Envoy's SNI-based listener selection is ever involved. That coalesced connection is still h2, so the frontend's own websocket (every HA browser session opens `/api/websocket` for live updates, same as the companion app) fails the same way the companion app originally did.
- This is exactly what Envoy Gateway's `OverlappingCertificates`/`OverlappingTLSConfig` status condition on the Gateway was warning about after #3251 merged - it defaults both overlapping listeners to `http/1.1` specifically to prevent this, and the explicit per-listener override in #3251 suppressed that protection.
- Fix: revert the extra listener/policy, and instead drop `h2` from the **shared** `ClientTrafficPolicy` so no downstream connection to any app can negotiate anything but HTTP/1.1. Also drops `http3` (and its now-inert `http2` tuning block) from the same policy, since HTTP/3 has the identical no-Upgrade-mechanism problem plus its own Alt-Svc-driven coalescing behavior - leaving it on would reopen the same hole over QUIC.
- Nothing in the cluster uses gRPC (no `GRPCRoute` anywhere), so there's no downstream HTTP/2 consumer to lose.

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/networking/envoy-gateway/app` renders cleanly, matches pre-#3251 shape
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes for the full tree
- [ ] After merge/reconcile, confirm both the HA companion app and browser access (including a browser tab that also has another `*.smbonn.me` app open, to specifically exercise the coalescing path) work reliably