### PR TITLE
fix(zigbee2mqtt): set pod securityContext to fix CrashLoopBackOff

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
@@ -72,6 +72,13 @@ spec:
                 cpu: 10m
               limits:
                 memory: 1Gi
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         controller: *app


### PR DESCRIPTION
## Summary
- zigbee2mqtt has been in `CrashLoopBackOff` since the Kopiur PVC cutover (#3214), crashing with `EACCES: permission denied, open '/config/configuration.yaml'`.
- Root cause: Kopiur's mover restores `/config` as UID/GID 1000 (its default `KOPIUR_PUID`/`KOPIUR_PGID`), but zigbee2mqtt's HelmRelease never set a pod-level `securityContext`. The container image has no `USER` directive, so it runs as root — and with `capabilities: { drop: ["ALL"] }` already set (dropping `CAP_DAC_OVERRIDE`), root can no longer implicitly write files it doesn't own. This worked pre-migration only because the app itself, running as root, originally created and owned those files.
- Fix: add `runAsUser: 1000` / `runAsGroup: 1000` / `fsGroup: 1000` to the pod securityContext, matching the pattern already used by `mosquitto`, `home-assistant`, `garage`, and `kopiur` itself.

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/home-automation/zigbee2mqtt/app` renders cleanly with the new `securityContext` block.
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes (`HelmRelease zigbee2mqtt is valid`, exit 0).
- [ ] Confirm pod comes up healthy and MQTT/Zigbee network reconnects after Flux reconciles.