### PR TITLE
feat(mysql): deploy MySQL InnoDB Cluster via mysql-operator

### DIFF
--- a/kubernetes/apps/databases/mysql/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/mysql/app/helmrelease.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mysql-operator
+spec:
+  chart:
+    spec:
+      chart: mysql-operator
+      version: "2.3.0"
+      sourceRef:
+        kind: HelmRepository
+        name: mysql-operator
+  interval: 30m

--- a/kubernetes/apps/databases/mysql/app/helmrepository.yaml
+++ b/kubernetes/apps/databases/mysql/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: mysql-operator
+spec:
+  interval: 1h
+  url: https://mysql.github.io/mysql-operator/

--- a/kubernetes/apps/databases/mysql/app/kustomization.yaml
+++ b/kubernetes/apps/databases/mysql/app/kustomization.yaml
@@ -2,11 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: databases
-components:
-  - ../../components/common
 resources:
-  - ./cloudnative-pg/ks.yaml
-  - ./mariadb/ks.yaml
-  - ./mysql/ks.yaml
-  - ./redis/ks.yaml
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/databases/mysql/cluster/backup-secret.yaml
+++ b/kubernetes/apps/databases/mysql/cluster/backup-secret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mysql-s3-backup
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mysql-s3-backup-secret
+    template:
+      engineVersion: v2
+      data:
+        credentials: |
+          [default]
+          aws_access_key_id = {{ .AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key = {{ .AWS_SECRET_ACCESS_KEY }}
+        config: |
+          [default]
+          region = us-east-1
+  dataFrom:
+    - extract:
+        key: mysql

--- a/kubernetes/apps/databases/mysql/cluster/externalsecret.yaml
+++ b/kubernetes/apps/databases/mysql/cluster/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mysql
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mysql-secret
+    template:
+      engineVersion: v2
+      data:
+        rootUser: "{{ .MYSQL_ROOT_USER }}"
+        rootHost: "%"
+        rootPassword: "{{ .MYSQL_ROOT_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: mysql

--- a/kubernetes/apps/databases/mysql/cluster/innodbcluster.yaml
+++ b/kubernetes/apps/databases/mysql/cluster/innodbcluster.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/mysql.oracle.com/innodbcluster_v2.json
+apiVersion: mysql.oracle.com/v2
+kind: InnoDBCluster
+metadata:
+  name: mysql
+spec:
+  secretName: mysql-secret
+  tlsUseSelfSigned: true
+  instances: 3
+  router:
+    instances: 1
+  datadirVolumeClaimTemplate:
+    accessModes:
+      - ReadWriteOnce
+    storageClassName: openebs-hostpath
+    resources:
+      requests:
+        storage: 20Gi
+  service:
+    type: LoadBalancer
+    annotations:
+      lbipam.cilium.io/ips: 192.168.1.12
+      gatus.home-operations.com/endpoint: |-
+        group: services
+  metrics:
+    enable: true
+    image: prom/mysqld-exporter:v0.19.0
+    monitor: true
+    options:
+      - --collect.perf_schema.replication_group_members
+      - --collect.perf_schema.replication_group_member_stats
+  backupProfiles:
+    - name: s3
+      dumpInstance:
+        storage:
+          s3:
+            bucketName: backups
+            prefix: mysql
+            config: mysql-s3-backup-secret
+            profile: default
+            endpoint: garage.storage.svc.cluster.local:3900
+  backupSchedules:
+    - name: daily
+      schedule: "0 3 * * *"
+      timeZone: America/New_York
+      backupProfileName: s3
+      enabled: true
+      deleteBackupData: false

--- a/kubernetes/apps/databases/mysql/cluster/kustomization.yaml
+++ b/kubernetes/apps/databases/mysql/cluster/kustomization.yaml
@@ -2,11 +2,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: databases
-components:
-  - ../../components/common
 resources:
-  - ./cloudnative-pg/ks.yaml
-  - ./mariadb/ks.yaml
-  - ./mysql/ks.yaml
-  - ./redis/ks.yaml
+  - ./backup-secret.yaml
+  - ./externalsecret.yaml
+  - ./innodbcluster.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/databases/mysql/cluster/prometheusrule.yaml
+++ b/kubernetes/apps/databases/mysql/cluster/prometheusrule.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: mysql
+spec:
+  groups:
+    - name: mysql.rules
+      rules:
+        - alert: MysqlInnoDBClusterSizeDegraded
+          annotations:
+            summary: MySQL InnoDB Cluster has {{ $value }} ONLINE members according to {{ $labels.instance }}, below the expected 3.
+          expr: count(mysql_perf_schema_replication_group_member_info{member_state="ONLINE"}) by (instance) < 3
+          for: 5m
+          labels:
+            severity: warning
+        - alert: MysqlInnoDBClusterMemberNotOnline
+          annotations:
+            summary: MySQL InnoDB Cluster member {{ $labels.member_id }} (seen from {{ $labels.instance }}) is in state {{ $labels.member_state }}, not ONLINE.
+          expr: mysql_perf_schema_replication_group_member_info{member_state!="ONLINE"}
+          for: 2m
+          labels:
+            severity: critical
+        - alert: MysqlInnoDBClusterApplierQueueBacklog
+          annotations:
+            summary: MySQL InnoDB Cluster node {{ $labels.instance }} has {{ $value }} transactions backlogged in its Group Replication applier queue.
+          expr: mysql_perf_schema_transactions_remote_in_applier_queue > 1000
+          for: 5m
+          labels:
+            severity: warning

--- a/kubernetes/apps/databases/mysql/ks.yaml
+++ b/kubernetes/apps/databases/mysql/ks.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mysql-operator
+  namespace: &namespace databases
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/defaults
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: kube-system
+  path: ./kubernetes/apps/databases/mysql/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true # mysql-cluster depends on this
+  interval: 30m
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mysql-cluster
+  namespace: &namespace databases
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/defaults
+  dependsOn:
+    - name: mysql-operator
+      namespace: databases
+  path: ./kubernetes/apps/databases/mysql/cluster
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false # no flux ks dependents
+  interval: 30m
+  timeout: 5m


### PR DESCRIPTION
## Summary
- Deploys Oracle's [mysql-operator](https://github.com/mysql/mysql-operator) + a 3-node MySQL InnoDB Cluster (Group Replication + Router) in the `databases` namespace, mirroring the existing `mariadb` app/cluster structure.
- Metrics via a `mysqld-exporter` sidecar + auto-created `ServiceMonitor`, plus a `PrometheusRule` alerting on Group Replication membership/backlog.
- Daily S3 backups (`spec.backupProfiles`/`spec.backupSchedules`) to the existing Garage endpoint, enabled from the start.

## Notes
- `mysql/mysql-operator` only publishes a classic Helm chart repo (no OCI artifact), so `app/` uses `HelmRepository` + `chart.spec.sourceRef` instead of this repo's usual `chartRef: OCIRepository`.
- The MySQL operator has no `User`/`Database`/`Grant` CRDs like mariadb-operator — nothing wired up for per-app schema/user provisioning yet since there's no consuming app.

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes (exit 0, no new errors)
- [x] `flate test all --path ./kubernetes/flux/cluster` passes (182 passed, only pre-existing unrelated warning)
- [ ] Confirm the `backups` bucket exists in Garage and the reused S3 key has access before this reconciles live
- [ ] Confirm `192.168.1.12` is free in the LB IP pool before this reconciles live