### PR TITLE
fix(mysql): set explicit k8sClusterDomain, auto-detect fails on rollout

### DIFF
--- a/kubernetes/apps/databases/mysql/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/mysql/app/helmrelease.yaml
@@ -12,3 +12,6 @@ spec:
         kind: HelmRepository
         name: mysql-operator
   interval: 30m
+  values:
+    envs:
+      k8sClusterDomain: cluster.local


### PR DESCRIPTION
## Summary
- After merging #3269, `mysql-operator` is crash-looping on rollout: `Failed to detect cluster domain. Reason: [Errno -2] Name or service not known`, ending in `Failed to automatically identify the cluster domain.`
- Cluster DNS itself is healthy (confirmed `cluster.local` via `/etc/resolv.conf` and the CoreDNS `Corefile`) - the operator's own auto-detection just doesn't work in this cluster.
- Sets `MYSQL_OPERATOR_K8S_CLUSTER_DOMAIN` explicitly via `values.envs.k8sClusterDomain: cluster.local`, bypassing detection.

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes
- [x] Confirmed cluster domain is `cluster.local` from a live pod's `/etc/resolv.conf` and the `coredns` ConfigMap
- [ ] Confirm `mysql-operator` pod goes Ready after this merges and reconciles