### PR TITLE
fix(mysql): pin MySQL Server/Router to 8.4.9, AzerothCore rejects 26.7.0

### DIFF
--- a/kubernetes/apps/databases/mysql/cluster/innodbcluster.yaml
+++ b/kubernetes/apps/databases/mysql/cluster/innodbcluster.yaml
@@ -8,8 +8,15 @@ spec:
   secretName: mysql-secret
   tlsUseSelfSigned: true
   instances: 3
+  # Pinned to the 8.4 LTS line, not the operator's default (26.7.0): AzerothCore's
+  # own MySQL version-compat check (DatabaseWorkerPool.cpp's DatabaseIncompatibleVersion)
+  # parses the server version string one character per component, which breaks on any
+  # double-digit major version and misreads 26.7.0 as older than its minimum (8.0.0),
+  # refusing the connection outright.
+  version: 8.4.9
   router:
     instances: 1
+    version: 8.4.9
   datadirVolumeClaimTemplate:
     accessModes:
       - ReadWriteOnce

--- a/kubernetes/apps/databases/mysql/cluster/innodbcluster.yaml
+++ b/kubernetes/apps/databases/mysql/cluster/innodbcluster.yaml
@@ -8,11 +8,6 @@ spec:
   secretName: mysql-secret
   tlsUseSelfSigned: true
   instances: 3
-  # Pinned to the 8.4 LTS line, not the operator's default (26.7.0): AzerothCore's
-  # own MySQL version-compat check (DatabaseWorkerPool.cpp's DatabaseIncompatibleVersion)
-  # parses the server version string one character per component, which breaks on any
-  # double-digit major version and misreads 26.7.0 as older than its minimum (8.0.0),
-  # refusing the connection outright.
   version: 8.4.9
   router:
     instances: 1


### PR DESCRIPTION
## Summary
- AzerothCore refuses to connect to the InnoDB Cluster with "AzerothCore does not support MySQL versions below 8.0", even though the cluster is running MySQL Server 26.7.0 (much newer, not older).
- Root cause is in AzerothCore's own version check (`DatabaseWorkerPool.cpp`'s `DatabaseIncompatibleVersion`): it parses the server version string one character per component, which only works for single-digit majors. Fed a double-digit major like `26.7.0` (Oracle's calendar-versioned MySQL Server line, the operator's default with no `spec.version` override), it misparses it as older than its hardcoded minimum `8.0.0` and rejects the connection - confirmed via the raw handshake banner that this happens identically whether connecting through Router (`26.7.0-router`) or straight to an instance (`26.7.0`).
- Pins `spec.version`/`spec.router.version` to `8.4.9` - the latest MySQL 8.4 LTS patch and AzerothCore's own documented recommended version.

## Notes
- The cluster needs to be **recreated**, not upgraded in place, to pick this up - MySQL/InnoDB Cluster doesn't support downgrading a live data directory across major versions. Safe here since the cluster never held any real data (AzerothCore was rejected at the handshake).

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes
- [ ] After merge: delete the live `InnoDBCluster` + PVCs and let Flux/the operator bootstrap fresh at 8.4.9
- [ ] Confirm AzerothCore connects successfully post-recreate