### PR TITLE
fix(mysql): disable TLS/SSL on the standalone server

### DIFF
--- a/kubernetes/apps/databases/mysql/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/mysql/app/helmrelease.yaml
@@ -19,6 +19,8 @@ spec:
             image:
               repository: public.ecr.aws/docker/library/mysql
               tag: 8.4.9
+            args:
+              - --skip-ssl
             envFrom:
               - secretRef:
                   name: mysql-secret


### PR DESCRIPTION
## Summary
- MySQL 8.4's official image auto-generates a self-signed cert and enables SSL on first startup; nothing here configures or distributes that cert.
- AzerothCore's seed tooling connects over TLS and fails validating the self-signed chain (`ERROR 2026 (HY000): TLS/SSL error: self-signed certificate in certificate chain`).
- Traffic is internal-only (matches how mariadb runs in this repo), so disable SSL on the server via `--skip-ssl` rather than standing up cert trust between the two.

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/databases/mysql/app` renders cleanly
- [ ] Flux reconciles, mysqld pod restarts with `--skip-ssl`, AzerothCore seed connects successfully