### PR TITLE
fix(mysql): use tls-version= instead of removed --skip-ssl flag

### DIFF
--- a/kubernetes/apps/databases/mysql/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/mysql/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
               repository: public.ecr.aws/docker/library/mysql
               tag: 8.4.9
             args:
-              - --skip-ssl
+              - --tls-version=
             envFrom:
               - secretRef:
                   name: mysql-secret


### PR DESCRIPTION
## Summary
- #3274 (merged) added `--skip-ssl` to disable TLS on the standalone MySQL server, but that flag — along with `--ssl` and `--admin-ssl` — was deprecated in MySQL 8.0.26 and removed outright in 8.4.
- mysqld is now crash-looping in the cluster: `[ERROR] [MY-000068] [Server] unknown option '--skip-ssl'.`
- Replace it with `--tls-version=` (empty value), the documented 8.4 way to disable TLS support on the main interface.

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/databases/mysql/app` renders cleanly
- [ ] Flux reconciles, mysqld pod starts successfully (no crash loop)
- [ ] AzerothCore seed connects successfully