### PR TITLE
fix(mysql): terminate TLS with the smbonn.me wildcard cert

### DIFF
--- a/kubernetes/apps/databases/mysql/app/externalsecret-tls.yaml
+++ b/kubernetes/apps/databases/mysql/app/externalsecret-tls.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://cluster-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mysql-tls
+spec:
+  refreshPolicy: CreatedOnce
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mysql-tls
+    creationPolicy: Orphan
+    template:
+      type: kubernetes.io/tls
+      metadata:
+        annotations:
+          cert-manager.io/alt-names: "*.smbonn.me,smbonn.me"
+          cert-manager.io/certificate-name: smbonn-me
+          cert-manager.io/common-name: smbonn.me
+          cert-manager.io/ip-sans: ""
+          cert-manager.io/issuer-group: ""
+          cert-manager.io/issuer-kind: ClusterIssuer
+          cert-manager.io/issuer-name: letsencrypt-production
+          cert-manager.io/uri-sans: ""
+        labels:
+          controller.cert-manager.io/fao: "true"
+  dataFrom:
+    - extract:
+        key: smbonn-me-tls
+        decodingStrategy: Base64

--- a/kubernetes/apps/databases/mysql/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/mysql/app/helmrelease.yaml
@@ -19,6 +19,9 @@ spec:
             image:
               repository: public.ecr.aws/docker/library/mysql
               tag: 8.4.9
+            args:
+              - --ssl-cert=/certs/tls.crt
+              - --ssl-key=/certs/tls.key
             envFrom:
               - secretRef:
                   name: mysql-secret
@@ -33,6 +36,7 @@ spec:
         controller: *app
         type: LoadBalancer
         annotations:
+          external-dns.alpha.kubernetes.io/hostname: mysql.smbonn.me
           lbipam.cilium.io/ips: 192.168.1.12
           gatus.home-operations.com/endpoint: |-
             group: services
@@ -46,3 +50,14 @@ spec:
         existingClaim: *app
         globalMounts:
           - path: /var/lib/mysql
+      tls:
+        enabled: true
+        type: secret
+        name: mysql-tls
+        globalMounts:
+          - path: /certs/tls.crt
+            subPath: tls.crt
+            readOnly: true
+          - path: /certs/tls.key
+            subPath: tls.key
+            readOnly: true

--- a/kubernetes/apps/databases/mysql/app/kustomization.yaml
+++ b/kubernetes/apps/databases/mysql/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-tls.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary
- MySQL's auto-generated self-signed cert has no SAN, so AzerothCore's connector fails hostname verification against `192.168.1.12` no matter what CA is trusted (confirmed live: installing the auto-generated CA on the AC host fixed "not trusted", then immediately hit "Hostname verification failed").
- Reuse the existing `letsencrypt-production` wildcard cert instead of minting another bespoke CA: give the service `mysql.smbonn.me` (same DNS pattern `cloudnative-pg` already uses for `postgres.smbonn.me`), import `smbonn-me-tls` into `databases` (same 1Password item `envoy-gateway` already consumes), and point `mysqld`'s `--ssl-cert`/`--ssl-key` at it.

## Follow-up outside this repo
AzerothCore's `LoginDatabaseInfo`/`WorldDatabaseInfo`/`CharacterDatabaseInfo` connection strings need to point at `mysql.smbonn.me` instead of `192.168.1.12` for the certificate to validate.

## Test plan
- [x] `kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/databases/mysql/app` renders cleanly
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes
- [x] `flate test all --path ./kubernetes/flux/cluster` — 180 passed, no new failures
- [ ] Flux reconciles, mysqld pod restarts with the wildcard cert, AzerothCore connects successfully over TLS