### PR TITLE
fix(mysql): match kopiur mover PUID/PGID to mysqld's actual uid

### DIFF
--- a/kubernetes/apps/databases/mysql/ks.yaml
+++ b/kubernetes/apps/databases/mysql/ks.yaml
@@ -31,3 +31,7 @@ spec:
     substitute:
       APP: *app
       KOPIUR_CAPACITY: 20Gi
+      # mysql official image runs mysqld as uid/gid 999, not kopiur's 1000 default;
+      # mismatch fails snapshots reading mysqld's 0600 auto-generated key files (server-key.pem etc)
+      KOPIUR_PUID: "999"
+      KOPIUR_PGID: "999"


### PR DESCRIPTION
## Summary
- Kopiur's hourly `SnapshotPolicy` for `mysql` was failing every run with `PermissionDenied`
- The mover defaulted to `runAsUser/runAsGroup: 1000` (kopiur's default), but the official `mysql:8.4.9` image runs mysqld as uid/gid `999`
- mysqld auto-generates several `0600`, owner-only key files (`server-key.pem`, `ca-key.pem`, `client-key.pem`, `private_key.pem`) that the uid-1000 mover couldn't read
- Fixed by setting `KOPIUR_PUID`/`KOPIUR_PGID` to `999` in `mysql/ks.yaml`'s `postBuild.substitute`, matching the app's real container user

## Test plan
- [x] `bash scripts/kubeconform.sh ./kubernetes` passes
- [x] Confirmed root cause live: `kubectl -n databases get snapshots.kopiur.home-operations.com mysql-<ts> -o yaml` showed `PermissionDenied` on the exact key files, and `kubectl exec` into the mysql pod confirmed mysqld runs as uid/gid 999
- [ ] Confirm the next scheduled snapshot (hourly) succeeds after this merges