### PR TITLE
fix(mysql): disable binary logging

### DIFF
--- a/kubernetes/apps/databases/mysql/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/mysql/app/helmrelease.yaml
@@ -20,6 +20,7 @@ spec:
               repository: public.ecr.aws/docker/library/mysql
               tag: 8.4.9
             args:
+              - --disable-log-bin
               - --ssl-cert=/certs/tls.crt
               - --ssl-key=/certs/tls.key
             envFrom:


### PR DESCRIPTION
## Why

`mysql` is a standalone server — `gtid_mode=OFF`, `server_id=1`, `SHOW REPLICAS` empty — so nothing consumes the binary logs, but MySQL 8.4 enables them by default.

Current state of the live datadir:

| | |
|---|---|
| Total `/var/lib/mysql` | 1.9 GB |
| Binlogs | **682 MB** (36%) |
| Active `binlog.000013` | 712 MB accumulated in ~24h |
| PVC capacity (`KOPIUR_CAPACITY`) | 20 Gi |

At ~700 MB/day against the default 30-day `binlog_expire_logs_seconds` (2592000), retention would reach ~21 GB — the volume fills before expiry ever purges anything. It also bloats every kopiur snapshot.

## What

Adds `--disable-log-bin` to the existing `args:` list, which the official image's entrypoint passes straight through to `mysqld` (same path the TLS flags already use).

## Verification

Booted `mysql:8.4.9` locally with the flag alongside the same SSL args this release uses:

```
@@log_bin = 0    @@log_bin_basename = NULL    version 8.4.9
binlog files created in datadir: 0
```

Server came up in 4s with no binlog-related errors.

The S3 logical backup is unaffected — `mariadb-dump` runs with `--single-transaction` and no `--source-data`/`--master-data`/`--flush-logs` (`/container/functions/10-dbbackup:613`).

## Trade-off

No point-in-time recovery between dumps. Covered by the daily `mysqldump` → S3 job plus kopiur PVC snapshots.

## Post-merge cleanup

Once `log_bin` is off, MySQL won't purge the existing `binlog.000001`–`000013`, and `PURGE BINARY LOGS` errors out when binary logging is disabled. After the pod restarts with logging off, `rm /var/lib/mysql/binlog.*` reclaims the 682 MB — safe at that point since nothing reads them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)