### PR TITLE
perf(mysql): tune connections, buffer pool, and durability

### DIFF
--- a/kubernetes/apps/databases/mysql/app/helmrelease.yaml
+++ b/kubernetes/apps/databases/mysql/app/helmrelease.yaml
@@ -23,15 +23,20 @@ spec:
               - --disable-log-bin
               - --ssl-cert=/certs/tls.crt
               - --ssl-key=/certs/tls.key
+              - --max-connections=500
+              - --max-allowed-packet=64M
+              - --wait-timeout=28800
+              - --innodb-buffer-pool-size=2G
+              - --innodb-flush-log-at-trx-commit=2
             envFrom:
               - secretRef:
                   name: mysql-secret
             resources:
               requests:
                 cpu: 100m
-                memory: 512Mi
+                memory: 3Gi
               limits:
-                memory: 2Gi
+                memory: 4Gi
     service:
       app:
         controller: *app


### PR DESCRIPTION
Raises the MySQL memory limit to 4Gi and sizes InnoDB to match, plus pins a few server variables explicitly.

## Changes

| Variable | Before | After | Rationale |
|---|---|---|---|
| `innodb_buffer_pool_size` | 128M (default) | **2G** | Total dataset is 581MB — the whole DB now fits in the pool with ~3x growth room |
| `innodb_flush_log_at_trx_commit` | 1 | **2** | Drops the per-commit fsync against Ceph RBD |
| `max_connections` | 151 (default) | **500** | Observed high-water mark is 31, so this is pure headroom |
| `wait_timeout` | 28800 (default) | **28800** | Pinned explicitly, unchanged |
| `max_allowed_packet` | 64M (default) | **64M** | Pinned explicitly, unchanged |
| `resources.limits.memory` | 2Gi | **4Gi** | |
| `resources.requests.memory` | 512Mi | **3Gi** | Buffer pool is allocated at startup; steady state ~2.9GB |

## Durability tradeoff

`innodb_flush_log_at_trx_commit=2` means up to ~1s of committed transactions can be lost **on a node/OS crash**. A mysqld process crash still loses nothing, since the redo log is written to the OS cache on every commit.

## Memory budget (4Gi limit)

Measured in the running pod: cgroup anon 868MB with a 128M pool, so non-pool baseline is ~740MB.

- Steady state: 740MB baseline + 2048MB pool + ~100MB (31 connections) = **~2.9GB**
- Worst case at all 500 connections: ~3.7GB, still under the limit

Node has ~60GiB allocatable at 31% requested, so the larger request schedules fine.

## Why args and not a config file

`docker-entrypoint.sh` does \`set -- mysqld \"\$@\"\` then \`exec \"\$@\"\`, so container args become mysqld startup options directly. All five are startup-only server variables. There is no \`mysqld-auto.cnf\` in the datadir, so nothing can \`SET PERSIST\` over these — git stays the source of truth.

## Validation

- \`mysqld --validate-config\` with the exact final arg list, run against 8.4.9 in the live pod → exit 0
- \`scripts/kubeconform.sh ./kubernetes\` → clean
- \`flate test all\` → 181 passed (the lone warning is pre-existing, on \`mariadb-operator\`)

## Rollout

The Deployment strategy is \`Recreate\` on an RWO \`ceph-block\` PVC, so this is a clean stop/start with ~30s of downtime — no rolling-update volume deadlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)